### PR TITLE
added cancel button to user edit

### DIFF
--- a/resources/js/Pages/Console/Users/Partials/UserProfile.vue
+++ b/resources/js/Pages/Console/Users/Partials/UserProfile.vue
@@ -124,6 +124,11 @@
     </template>
 
     <template #actions>
+      <jet-secondary-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing"
+          @click="back"
+        >
+          Cancel
+      </jet-secondary-button>
       <jet-action-message :on="form.recentlySuccessful" class="mr-3">
         Saved.
       </jet-action-message>
@@ -234,6 +239,10 @@ export default {
         this.$refs.photo.value = null;
       }
       
+    },
+
+    back() {
+      window.history.back();
     },
   },
 };


### PR DESCRIPTION
The cancel button goes back. That is my understanding of cancel. There could also be a reset function, restoring the original values. Or we could have both. From usability point of view, the cancel button should go next to submit, I think. But strictly speaking, it cancels all of the page, so it should go perhaps below both sections.