### PR TITLE
Disable user account delete option. Fixes #327

### DIFF
--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -46,7 +46,7 @@ return [
         Features::profilePhotos(),
         Features::api(),
         Features::teams(['invitations' => true]),
-        Features::accountDeletion(),
+        // Features::accountDeletion(),
     ],
 
     /*


### PR DESCRIPTION
Disabling the option to delete user's own account - until we have a standard procedure established for obsolete studies/projects