### PR TITLE
fix: add next line to project archival notify admin mail body.

### DIFF
--- a/resources/views/vendor/mail/project-archival-notify-admins.blade.php
+++ b/resources/views/vendor/mail/project-archival-notify-admins.blade.php
@@ -18,4 +18,8 @@ The nmrXiv Team
 View Project
 @endcomponent
 
+@component('mail::subcopy')
+You are recieving this mail because you are part of the admin list in nmrXiv.
+@endcomponent
+
 @endcomponent

--- a/resources/views/vendor/mail/project-archival-notify-admins.blade.php
+++ b/resources/views/vendor/mail/project-archival-notify-admins.blade.php
@@ -4,8 +4,11 @@ Dear admin,
 
 The below project has been archived.
 
-{{ __('Project Name - **:project**', ['project' => $projectName]) }}
-{{ __('Project ID - **:projectId**', ['projectId' => $projectId]) }}
+{{ __('**Project Name**:') }}
+{{ __(':project', ['project' => $projectName]) }}
+
+{{ __('**Project Id**:') }}
+{{ __(':projectId', ['projectId' => $projectId]) }}
 
 Regards,
 


### PR DESCRIPTION
fixes #721

@CS76 I think addressing as admin makes it easy to distinguish that this mail is for admin purposes and not for personal.

![image](https://user-images.githubusercontent.com/54287612/212827884-3e5bf429-0348-4a5a-a415-6bf6a526ffc7.png)
