### PR TITLE
fix: deleted package-name and prerelease

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,6 +66,4 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         with:
           release-type: php
-          package-name: release-please-action
           token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: true


### PR DESCRIPTION
 - fixes the github actions deprecation warning for node v16