### PR TITLE
feat: unify identifiers representation (molecules to projects and spectra

### DIFF
--- a/resources/js/App/MoleculeCard.vue
+++ b/resources/js/App/MoleculeCard.vue
@@ -51,7 +51,7 @@
                     </div>
                     <div class="font-bold text-md mb-2">
                         <a class="font-semibold text-gray-600 hover:underline"
-                            >#NMRXIV:{{ molecule.identifier }}</a
+                            >#NMRXIV:M{{ molecule.identifier }}</a
                         >
                     </div>
                     <div


### PR DESCRIPTION
fixes #1118

Before: 
![image](https://github.com/NFDI4Chem/nmrxiv/assets/82588017/c01773a7-7f97-46e5-b49b-2fc231a7c289)

After
<img width="587" alt="Screenshot 2024-04-29 at 15 02 09" src="https://github.com/NFDI4Chem/nmrxiv/assets/82588017/823caf50-4b00-41f6-a743-505cdeb4fb37">

Which fits with projects/ spectra identifiers: 
<img width="280" alt="image" src="https://github.com/NFDI4Chem/nmrxiv/assets/82588017/9c66c7bf-98b8-403b-9198-87ec37266af8">
