### PR TITLE
fix: display public samples in the absence of projects.

### DIFF
--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -44,7 +44,10 @@
                 </div>
             </div>
         </template>
-        <div v-if="projects.length > 0" class="px-8 py-8 mx-auto max-w-4xl">
+        <div
+            v-if="projects.length > 0 || samples.length > 0"
+            class="px-8 py-8 mx-auto max-w-4xl"
+        >
             <div>
                 <div class="sm:hidden">
                     <label for="tabs" class="sr-only">Select a tab</label>

--- a/resources/js/Pages/Project/Index.vue
+++ b/resources/js/Pages/Project/Index.vue
@@ -35,8 +35,9 @@
                     <div class="mt-3 max-w-2xl text-sm text-gray-700">
                         nmrXiv is organized around projects. Projects can
                         contain as many samples as you wish and each sample
-                        receives its very own URL. To learn more, check out our
-                        documentation.
+                        receives its very own URL. Use the "UPLOAD" button on
+                        the upper left side to start uploading projects or
+                        samples. To learn more, check out our documentation.
                     </div>
                     <!-- <button
                         type="button"


### PR DESCRIPTION
fixes #1122

Before: After the user publishes a sample without publishing any projects, they get this view:
<img width="1237" alt="image" src="https://github.com/NFDI4Chem/nmrxiv/assets/82588017/4604ee7f-13ca-462a-99e9-c8de96ff6a6e">

Now: 
<img width="1128" alt="image" src="https://github.com/NFDI4Chem/nmrxiv/assets/82588017/91145b03-196d-44a3-b3e4-6273c5b65703">

<img width="627" alt="image" src="https://github.com/NFDI4Chem/nmrxiv/assets/82588017/e2df759f-f7a3-4479-947b-755bff80e99c">


