### PR TITLE
fix: standardise the dates displayed by datepicker

### DIFF
--- a/resources/js/Mixins/Global.js
+++ b/resources/js/Mixins/Global.js
@@ -336,6 +336,15 @@ export default {
             }
             return query.trim();
         },
+        customDateFormat(date) {
+            if (!date) return "";
+            const day = String(date.getDate()).padStart(2, "0");
+            const month = String(date.getMonth() + 1).padStart(2, "0");
+            const year = date.getFullYear();
+            const hours = String(date.getHours()).padStart(2, "0");
+            const minutes = String(date.getMinutes()).padStart(2, "0");
+            return `${day}/${month}/${year}, ${hours}:${minutes}`;
+        },
     },
 
     computed: {

--- a/resources/js/Pages/Announcement/Partials/Create.vue
+++ b/resources/js/Pages/Announcement/Partials/Create.vue
@@ -75,6 +75,8 @@
                         <Datepicker
                             v-model="createAnnouncementForm.start_time"
                             :min-date="new Date()"
+                            :format="customFormat"
+                            :preview-format="customFormat"
                         ></Datepicker>
                         <jet-input-error
                             :message="createAnnouncementForm.errors.start_time"
@@ -90,6 +92,8 @@
                         </label>
                         <Datepicker
                             v-model="createAnnouncementForm.end_time"
+                            :format="customFormat"
+                            :preview-format="customFormat"
                         ></Datepicker>
                         <jet-input-error
                             :message="createAnnouncementForm.errors.end_time"
@@ -161,6 +165,23 @@ export default {
     },
 
     props: [],
+
+    setup() {
+        // Custom format function
+        const customFormat = (date) => {
+            if (!date) return "";
+            const day = String(date.getDate()).padStart(2, "0");
+            const month = String(date.getMonth() + 1).padStart(2, "0");
+            const year = date.getFullYear();
+            const hours = String(date.getHours()).padStart(2, "0");
+            const minutes = String(date.getMinutes()).padStart(2, "0");
+            return `${day}/${month}/${year}, ${hours}:${minutes}`;
+        };
+
+        return {
+            customFormat,
+        };
+    },
 
     data() {
         return {

--- a/resources/js/Pages/Announcement/Partials/Create.vue
+++ b/resources/js/Pages/Announcement/Partials/Create.vue
@@ -75,8 +75,8 @@
                         <Datepicker
                             v-model="createAnnouncementForm.start_time"
                             :min-date="new Date()"
-                            :format="customFormat"
-                            :preview-format="customFormat"
+                            :format="customDateFormat"
+                            :preview-format="customDateFormat"
                         ></Datepicker>
                         <jet-input-error
                             :message="createAnnouncementForm.errors.start_time"
@@ -92,8 +92,8 @@
                         </label>
                         <Datepicker
                             v-model="createAnnouncementForm.end_time"
-                            :format="customFormat"
-                            :preview-format="customFormat"
+                            :format="customDateFormat"
+                            :preview-format="customDateFormat"
                         ></Datepicker>
                         <jet-input-error
                             :message="createAnnouncementForm.errors.end_time"
@@ -165,23 +165,6 @@ export default {
     },
 
     props: [],
-
-    setup() {
-        // Custom format function
-        const customFormat = (date) => {
-            if (!date) return "";
-            const day = String(date.getDate()).padStart(2, "0");
-            const month = String(date.getMonth() + 1).padStart(2, "0");
-            const year = date.getFullYear();
-            const hours = String(date.getHours()).padStart(2, "0");
-            const minutes = String(date.getMinutes()).padStart(2, "0");
-            return `${day}/${month}/${year}, ${hours}:${minutes}`;
-        };
-
-        return {
-            customFormat,
-        };
-    },
 
     data() {
         return {

--- a/resources/js/Pages/Announcement/Partials/Edit.vue
+++ b/resources/js/Pages/Announcement/Partials/Edit.vue
@@ -75,6 +75,8 @@
                         <Datepicker
                             v-model="editAnnouncementForm.start_time"
                             :min-date="new Date()"
+                            :format="customFormat"
+                            :preview-format="customFormat"
                         ></Datepicker>
                         <jet-input-error
                             :message="editAnnouncementForm.errors.start_time"
@@ -87,6 +89,8 @@
                         </label>
                         <Datepicker
                             v-model="editAnnouncementForm.end_time"
+                            :format="customFormat"
+                            :preview-format="customFormat"
                         ></Datepicker>
                         <jet-input-error
                             :message="editAnnouncementForm.errors.end_time"
@@ -157,6 +161,22 @@ export default {
     },
 
     props: [],
+    setup() {
+        // Custom format function
+        const customFormat = (date) => {
+            if (!date) return "";
+            const day = String(date.getDate()).padStart(2, "0");
+            const month = String(date.getMonth() + 1).padStart(2, "0");
+            const year = date.getFullYear();
+            const hours = String(date.getHours()).padStart(2, "0");
+            const minutes = String(date.getMinutes()).padStart(2, "0");
+            return `${day}/${month}/${year}, ${hours}:${minutes}`;
+        };
+
+        return {
+            customFormat,
+        };
+    },
 
     data() {
         return {

--- a/resources/js/Pages/Announcement/Partials/Edit.vue
+++ b/resources/js/Pages/Announcement/Partials/Edit.vue
@@ -75,8 +75,8 @@
                         <Datepicker
                             v-model="editAnnouncementForm.start_time"
                             :min-date="new Date()"
-                            :format="customFormat"
-                            :preview-format="customFormat"
+                            :format="customDateFormat"
+                            :preview-format="customDateFormat"
                         ></Datepicker>
                         <jet-input-error
                             :message="editAnnouncementForm.errors.start_time"
@@ -89,8 +89,8 @@
                         </label>
                         <Datepicker
                             v-model="editAnnouncementForm.end_time"
-                            :format="customFormat"
-                            :preview-format="customFormat"
+                            :format="customDateFormat"
+                            :preview-format="customDateFormat"
                         ></Datepicker>
                         <jet-input-error
                             :message="editAnnouncementForm.errors.end_time"
@@ -161,22 +161,6 @@ export default {
     },
 
     props: [],
-    setup() {
-        // Custom format function
-        const customFormat = (date) => {
-            if (!date) return "";
-            const day = String(date.getDate()).padStart(2, "0");
-            const month = String(date.getMonth() + 1).padStart(2, "0");
-            const year = date.getFullYear();
-            const hours = String(date.getHours()).padStart(2, "0");
-            const minutes = String(date.getMinutes()).padStart(2, "0");
-            return `${day}/${month}/${year}, ${hours}:${minutes}`;
-        };
-
-        return {
-            customFormat,
-        };
-    },
 
     data() {
         return {

--- a/resources/js/Pages/Project/Show.vue
+++ b/resources/js/Pages/Project/Show.vue
@@ -560,9 +560,9 @@
                                                     v-model="
                                                         project.release_date
                                                     "
-                                                    :format="customFormat"
+                                                    :format="customDateFormat"
                                                     :preview-format="
-                                                        customFormat
+                                                        customDateFormat
                                                     "
                                                 ></Datepicker>
                                                 <p
@@ -1102,21 +1102,10 @@ export default {
         const manageAuthorElement = ref(null);
         const manageCitationElement = ref(null);
 
-        // Custom format function
-        const customFormat = (date) => {
-            if (!date) return "";
-            const day = String(date.getDate()).padStart(2, "0");
-            const month = String(date.getMonth() + 1).padStart(2, "0");
-            const year = date.getFullYear();
-            const hours = String(date.getHours()).padStart(2, "0");
-            const minutes = String(date.getMinutes()).padStart(2, "0");
-            return `${day}/${month}/${year}, ${hours}:${minutes}`;
-        };
         return {
             projectDetailsElement,
             manageAuthorElement,
             manageCitationElement,
-            customFormat,
         };
     },
     data() {

--- a/resources/js/Pages/Project/Show.vue
+++ b/resources/js/Pages/Project/Show.vue
@@ -560,6 +560,10 @@
                                                     v-model="
                                                         project.release_date
                                                     "
+                                                    :format="customFormat"
+                                                    :preview-format="
+                                                        customFormat
+                                                    "
                                                 ></Datepicker>
                                                 <p
                                                     class="mt-1 text-sm text-gray-500"
@@ -1097,10 +1101,22 @@ export default {
         const projectDetailsElement = ref(null);
         const manageAuthorElement = ref(null);
         const manageCitationElement = ref(null);
+
+        // Custom format function
+        const customFormat = (date) => {
+            if (!date) return "";
+            const day = String(date.getDate()).padStart(2, "0");
+            const month = String(date.getMonth() + 1).padStart(2, "0");
+            const year = date.getFullYear();
+            const hours = String(date.getHours()).padStart(2, "0");
+            const minutes = String(date.getMinutes()).padStart(2, "0");
+            return `${day}/${month}/${year}, ${hours}:${minutes}`;
+        };
         return {
             projectDetailsElement,
             manageAuthorElement,
             manageCitationElement,
+            customFormat,
         };
     },
     data() {

--- a/resources/js/Pages/Publish.vue
+++ b/resources/js/Pages/Publish.vue
@@ -431,6 +431,8 @@
                                 v-model="publishForm.release_date"
                                 @update:modelValue="updateProject"
                                 :min-date="new Date()"
+                                :format="customFormat"
+                                :preview-format="customFormat"
                             ></Datepicker>
                             <p class="mt-1 text-sm text-gray-500">
                                 Publish your data now immediately or set a
@@ -860,9 +862,22 @@ export default {
     setup() {
         const manageAuthorElement = ref(null);
         const manageCitationElement = ref(null);
+
+        // Custom format function
+        const customFormat = (date) => {
+            if (!date) return "";
+            const day = String(date.getDate()).padStart(2, "0");
+            const month = String(date.getMonth() + 1).padStart(2, "0");
+            const year = date.getFullYear();
+            const hours = String(date.getHours()).padStart(2, "0");
+            const minutes = String(date.getMinutes()).padStart(2, "0");
+            return `${day}/${month}/${year}, ${hours}:${minutes}`;
+        };
+
         return {
             manageAuthorElement,
             manageCitationElement,
+            customFormat,
         };
     },
 

--- a/resources/js/Pages/Publish.vue
+++ b/resources/js/Pages/Publish.vue
@@ -431,8 +431,8 @@
                                 v-model="publishForm.release_date"
                                 @update:modelValue="updateProject"
                                 :min-date="new Date()"
-                                :format="customFormat"
-                                :preview-format="customFormat"
+                                :format="customDateFormat"
+                                :preview-format="customDateFormat"
                             ></Datepicker>
                             <p class="mt-1 text-sm text-gray-500">
                                 Publish your data now immediately or set a
@@ -862,22 +862,9 @@ export default {
     setup() {
         const manageAuthorElement = ref(null);
         const manageCitationElement = ref(null);
-
-        // Custom format function
-        const customFormat = (date) => {
-            if (!date) return "";
-            const day = String(date.getDate()).padStart(2, "0");
-            const month = String(date.getMonth() + 1).padStart(2, "0");
-            const year = date.getFullYear();
-            const hours = String(date.getHours()).padStart(2, "0");
-            const minutes = String(date.getMinutes()).padStart(2, "0");
-            return `${day}/${month}/${year}, ${hours}:${minutes}`;
-        };
-
         return {
             manageAuthorElement,
             manageCitationElement,
-            customFormat,
         };
     },
 


### PR DESCRIPTION
fixes #1153

Before:
<img width="1300" alt="Screenshot 2024-07-30 at 15 56 29" src="https://github.com/user-attachments/assets/208d7076-900b-4e06-a547-e3a0ebba6b72">

After:
<img width="1283" alt="Screenshot 2024-07-30 at 15 54 59" src="https://github.com/user-attachments/assets/94f76467-ed26-41ea-b54e-d07d04c1d748">
