### PR TITLE
fix: add citation banner to public samples wherever missing

### DIFF
--- a/app/Http/Resources/StudyResource.php
+++ b/app/Http/Resources/StudyResource.php
@@ -40,6 +40,7 @@ class StudyResource extends JsonResource
             'identifier' => $this->identifier,
             'doi' => $this->doi,
             'created_at' => $this->created_at,
+            'release_date' => $this->release_date,
             'is_public' => $this->is_public,
             'public_url' => $this->public_url ? $this->public_url : null,
             'updated_at' => $this->updated_at,

--- a/resources/js/Pages/Public/Project/Study.vue
+++ b/resources/js/Pages/Public/Project/Study.vue
@@ -5,6 +5,20 @@
             <div
                 class="pb-10 mb-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6"
             >
+                <div
+                    class="-mx-4"
+                    v-if="study.data.is_public && study.data.doi != null"
+                >
+                    <Citation
+                        :model="'sample'"
+                        :doi="study.data.doi"
+                    ></Citation>
+                    <ShowProjectDates
+                        class="ml-5"
+                        :release_date="study.data.release_date"
+                        :created_at="study.data.created_at"
+                    />
+                </div>
                 <h1 class="mt-2 text-2xl font-bold break-words text-gray-900">
                     <div class="text-blue-500">
                         {{ study.data.name }}
@@ -446,6 +460,8 @@ import SpectraViewer from "@/Shared/SpectraViewer.vue";
 import Depictor2D from "@/Shared/Depictor2D.vue";
 import DOIBadge from "@/Shared/DOIBadge.vue";
 import { Head } from "@inertiajs/vue3";
+import Citation from "@/Shared/Citation.vue";
+import ShowProjectDates from "@/Shared/ShowProjectDates.vue";
 
 export default {
     components: {
@@ -460,6 +476,8 @@ export default {
         Depictor2D,
         DOIBadge,
         Head,
+        Citation,
+        ShowProjectDates,
     },
     props: ["project", "tab", "study"],
     data() {

--- a/resources/js/Pages/Public/Sample/Show.vue
+++ b/resources/js/Pages/Public/Sample/Show.vue
@@ -5,6 +5,21 @@
             <div
                 class="pb-10 mb-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6"
             >
+                <div
+                    class="-mx-4"
+                    v-if="study.data.is_public && study.data.doi != null"
+                >
+                    <Citation
+                        :model="'sample'"
+                        :doi="study.data.doi"
+                    ></Citation>
+                    <ShowProjectDates
+                        class="ml-5"
+                        :release_date="study.data.release_date"
+                        :created_at="study.data.created_at"
+                    />
+                </div>
+
                 <div class="border-b border-gray-200 pb-5">
                     <div class="sm:flex sm:items-baseline sm:justify-between">
                         <div class="sm:w-0 sm:flex-1">
@@ -498,6 +513,8 @@ import SpectraViewer from "@/Shared/SpectraViewer.vue";
 import Depictor2D from "@/Shared/Depictor2D.vue";
 import DOIBadge from "@/Shared/DOIBadge.vue";
 import { Head } from "@inertiajs/vue3";
+import Citation from "@/Shared/Citation.vue";
+import ShowProjectDates from "@/Shared/ShowProjectDates.vue";
 
 export default {
     components: {
@@ -512,6 +529,8 @@ export default {
         Depictor2D,
         DOIBadge,
         Head,
+        Citation,
+        ShowProjectDates,
     },
     props: ["project", "tab", "study"],
     data() {


### PR DESCRIPTION
fixes  #1156

Before:
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/5007f1f4-d2a0-42f3-a22f-0e9ebf0907a1">


After:
<img width="1607" alt="image" src="https://github.com/user-attachments/assets/7923909a-f6c5-4316-a00c-e1b4dd4b7b53">
