### PR TITLE
fix: remove project photo placeholder

### DIFF
--- a/resources/js/Pages/Project/Show.vue
+++ b/resources/js/Pages/Project/Show.vue
@@ -311,13 +311,9 @@
                             class="flex-nowrap right ml-auto"
                         >
                             <img
-                                :src="
-                                    project.project_photo_url
-                                        ? project.project_photo_url
-                                        : 'https://via.placeholder.com/400x200'
-                                "
-                                :alt="project.name"
-                                class="h-24 w-72 rounded-md object-cover"
+                                v-if="project.project_photo_url"
+                                :src="project.project_photo_url"
+                                class="h-24 w-72 -ml-4 rounded-md object-cover"
                             />
                         </div>
                         <div class="flex-nowrap">


### PR DESCRIPTION
fixes  #1171

Before: 

project that doesn't have a photo: 
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/5a168746-1429-4840-9851-7587988a6643">


project that has a photo:
<img width="1167" alt="image" src="https://github.com/user-attachments/assets/d62e7cf9-4a3d-4909-8049-f12b1cdbe1de">


After:
project that doesn't have a photo:
<img width="1155" alt="image" src="https://github.com/user-attachments/assets/8baba36e-10d3-4039-8064-68a7166c65a5">

project that has a photo:
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/ba383688-aa02-4891-8f91-3f7f6391ca6e">
