### PR TITLE
build: add smoke test for worker and app docker images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,5 +139,5 @@ CSP_ENABLED_WHILE_HOT_RELOADING=false
 # CSP_ADDITIONAL_SCRIPT_SRC="https://cdn.example.com"
 # CSP_ADDITIONAL_STYLE_SRC="https://fonts.example.com"
 
-ROR_API_URL=https://api.ror.org/v2/organizations
+ROR_API_URL=https://api.ror.org/organizations
 ROR_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -138,3 +138,6 @@ CSP_ENABLED_WHILE_HOT_RELOADING=false
 # CSP_ADDITIONAL_IMG_SRC="https://cdn.example.com,https://images.example.com"
 # CSP_ADDITIONAL_SCRIPT_SRC="https://cdn.example.com"
 # CSP_ADDITIONAL_STYLE_SRC="https://fonts.example.com"
+
+ROR_API_URL=https://api.ror.org/v2/organizations
+ROR_CLIENT_ID=

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -16,8 +16,9 @@ env:
   REPOSITORY_NAMESPACE: nfdi4chem
 
 jobs:
+  #Lint and Security check
   lint-security:
-    name: Lint & Security (reusable)
+    name: Lint & Security
     uses: ./.github/workflows/lint-security-check.yml
     permissions:
       contents: read
@@ -27,11 +28,33 @@ jobs:
       run_js: true
       run_secrets: true
 
-  # Build and publish Docker images for the development environment
-  setup-build-publish-deploy:
-    name: Build & deploy to development
-    runs-on: ubuntu-latest
+  # Run tests and collect coverage
+  test-coverage:
+    name: Tests & Coverage
+    uses: ./.github/workflows/test-coverage.yml
     needs: [lint-security]
+    secrets: inherit
+
+  # Smoke test Docker images before pushing
+  smoke-test:
+    name: Smoke test Docker images
+    uses: ./.github/workflows/docker-smoke-test.yml
+    needs: [test-coverage]
+
+  # Build and publish Docker images for the development environment
+  build-and-push:
+    name: Build & push to Docker Hub
+    runs-on: ubuntu-latest
+    needs: [test-coverage, smoke-test, lint-security]
+    strategy:
+      matrix:
+        image:
+          - name: app
+            file: ./deployment/Dockerfile
+            tag: app-dev-latest
+          - name: worker
+            file: ./deployment/Dockerfile.worker
+            tag: worker-dev-latest
 
     # Environment provides secrets and protection rules
     environment:
@@ -52,28 +75,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Build + push app image (tag: app-dev-latest). Uses GHA cache for speed.
-      - name: Build and push App Docker image
+      # Build and push image
+      - name: Build and push ${{ matrix.image.name }} image
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./deployment/Dockerfile
+          file: ${{ matrix.image.file }}
           push: true
           build-args: |
-            RELEASE_VERSION=app-dev-latest
-          tags: ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:app-dev-latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # Build + push worker image (tag: worker-dev-latest)
-      - name: Build and push Worker Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./deployment/Dockerfile.worker
-          push: true
-          build-args: |
-            RELEASE_VERSION=worker-dev-latest
-          tags: ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:worker-dev-latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            RELEASE_VERSION=${{ matrix.image.tag }}
+          tags: ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:${{ matrix.image.tag }}
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -16,7 +16,7 @@ env:
   REPOSITORY_NAMESPACE: nfdi4chem
 
 jobs:
-  #Lint and Security check
+  # Lint and Security check
   lint-security:
     name: Lint & Security
     uses: ./.github/workflows/lint-security-check.yml

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,8 +1,5 @@
 name: Docker Image Smoke Tests
 
-# on:
-#   workflow_call:
-
 on:
   push:
     branches: [add-smoke-test-frankenphp]

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,66 @@
+name: Docker Image Smoke Tests
+
+# on:
+#   workflow_call:
+
+on:
+  push:
+    branches: [add-smoke-test-frankenphp]
+
+env:
+  REPOSITORY_NAME: nmrxiv
+  REPOSITORY_NAMESPACE: nfdi4chem
+
+jobs:
+  smoke-test:
+    name: Smoke test containers
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - name: app
+            file: ./deployment/Dockerfile
+            wait-time: 60
+          - name: worker
+            file: ./deployment/Dockerfile.worker
+            wait-time: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and export ${{ matrix.container.name }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.container.file }}
+          load: true
+          tags: ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:${{ matrix.container.name }}-test
+          cache-from: type=gha,scope=${{ matrix.container.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.container.name }}
+
+      - name: Start ${{ matrix.container.name }} container
+        run: |
+          docker run -d --name nmrxiv-${{ matrix.container.name }}-test \
+            -e APP_KEY=base64:$(openssl rand -base64 32) \
+            -e APP_ENV=production \
+            -e DB_CONNECTION=sqlite \
+            -e CACHE_STORE=array \
+            -e SESSION_DRIVER=array \
+            -e QUEUE_CONNECTION=sync \
+            ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:${{ matrix.container.name }}-test
+
+      - name: Wait for ${{ matrix.container.name }} container health
+        uses: stringbean/docker-healthcheck-action@v3
+        with:
+          container: nmrxiv-${{ matrix.container.name }}-test
+          wait-time: ${{ matrix.container.wait-time }}
+          require-status: running
+          require-healthy: true
+
+      - name: Cleanup ${{ matrix.container.name }} container
+        if: always()
+        run: docker rm -f nmrxiv-${{ matrix.container.name }}-test

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,8 +1,7 @@
 name: Docker Image Smoke Tests
 
 on:
-  push:
-    branches: [add-smoke-test-frankenphp]
+  workflow_call:
 
 env:
   REPOSITORY_NAME: nmrxiv
@@ -21,7 +20,7 @@ jobs:
             wait-time: 60
           - name: worker
             file: ./deployment/Dockerfile.worker
-            wait-time: 30
+            wait-time: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -20,22 +20,10 @@ env:
   REPOSITORY_NAMESPACE: nfdi4chem
 
 jobs:
-  lint-security:
-    name: Lint & Security (reusable)
-    uses: ./.github/workflows/lint-security-check.yml
-    permissions:
-      contents: read
-      security-events: write
-    with:
-      run_php: true
-      run_js: true
-      run_secrets: true
-
   # Guard: confirm input and authorize actor
   guard:
     name: Access control and confirmation
     runs-on: ubuntu-latest
-    needs: [lint-security]
     steps:
       - name: Validate actor and confirmation
         shell: bash
@@ -62,11 +50,43 @@ jobs:
           fi
           echo "Authorization check passed."
 
-  # Build and publish Docker images for the production environment
-  setup-build-publish-deploy-prod:
-    name: Deploy to prod
-    runs-on: ubuntu-latest
+  lint-security:
+    name: Lint & Security
+    uses: ./.github/workflows/lint-security-check.yml
     needs: [guard]
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      run_php: true
+      run_js: true
+      run_secrets: true
+
+  # Run tests and collect coverage
+  test-coverage:
+    name: Tests & Coverage
+    uses: ./.github/workflows/test-coverage.yml
+    needs: [guard, lint-security]
+    secrets: inherit
+
+  # Smoke test Docker images before pushing
+  smoke-test:
+    name: Smoke test Docker images
+    uses: ./.github/workflows/docker-smoke-test.yml
+    needs: [guard, test-coverage]
+
+  # Build and publish Docker images for the production environment
+  build-and-push:
+    name: Build & push to Docker Hub
+    runs-on: ubuntu-latest
+    needs: [guard, test-coverage, smoke-test]
+    strategy:
+      matrix:
+        image:
+          - name: app
+            file: ./deployment/Dockerfile
+          - name: worker
+            file: ./deployment/Dockerfile.worker
     environment:
       name: Prod
     steps:
@@ -102,34 +122,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Build + push app image (tags: release, sha, latest). Uses GHA cache.
-      - name: Build and push App Docker image
+      # Build and push image
+      - name: Build and push ${{ matrix.image.name }} image
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./deployment/Dockerfile
+          file: ${{ matrix.image.file }}
           push: true
           build-args: |
             RELEASE_VERSION=${{ steps.fetch-latest-release.outputs.tag_name }}
           tags: |
-            ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:app-sha-${{ steps.fetch-latest-release.outputs.sha_short }}
-            ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:app-${{ steps.fetch-latest-release.outputs.tag_name }}
-            ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:app-latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # Build + push worker image (tags: release, sha, latest)
-      - name: Build and push Worker Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./deployment/Dockerfile.worker
-          push: true
-          build-args: |
-            RELEASE_VERSION=${{ steps.fetch-latest-release.outputs.tag_name }}
-          tags: |
-            ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:worker-sha-${{ steps.fetch-latest-release.outputs.sha_short }}
-            ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:worker-${{ steps.fetch-latest-release.outputs.tag_name }}
-            ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:worker-latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:${{ matrix.image.name }}-sha-${{ steps.fetch-latest-release.outputs.sha_short }}
+            ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:${{ matrix.image.name }}-${{ steps.fetch-latest-release.outputs.tag_name }}
+            ${{ env.REPOSITORY_NAMESPACE }}/${{ env.REPOSITORY_NAME }}:${{ matrix.image.name }}-latest
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -77,6 +77,10 @@ COPY deployment/Caddyfile /etc/caddy/Caddyfile
 
 RUN php artisan l5-swagger:generate
 
+# Add healthcheck - verify Octane server is responding
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD curl -f http://localhost/octane-test || exit 1
+
 # Expose port
 EXPOSE 80 443
 

--- a/deployment/Dockerfile.worker
+++ b/deployment/Dockerfile.worker
@@ -66,5 +66,9 @@ COPY deployment/supervisord.worker.conf /etc/supervisor/conf.d/supervisord.conf
 # Create required directories for Supervisor
 RUN mkdir -p /var/log/supervisor /run/supervisor
 
+# Add healthcheck - verify supervisor and processes are running
+HEALTHCHECK --interval=10s --timeout=5s --start-period=20s --retries=3 \
+  CMD supervisorctl status | grep -q RUNNING || exit 1
+
 # Start Supervisord
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"] 

--- a/deployment/Dockerfile.worker
+++ b/deployment/Dockerfile.worker
@@ -66,9 +66,9 @@ COPY deployment/supervisord.worker.conf /etc/supervisor/conf.d/supervisord.conf
 # Create required directories for Supervisor
 RUN mkdir -p /var/log/supervisor /run/supervisor
 
-# Add healthcheck - verify supervisor and processes are running
-HEALTHCHECK --interval=10s --timeout=5s --start-period=20s --retries=3 \
-  CMD supervisorctl status | grep -q RUNNING || exit 1
+# Add healthcheck - verify Horizon process is running
+HEALTHCHECK --interval=10s --timeout=3s --start-period=30s --retries=3 \
+  CMD pgrep -f "artisan horizon" || exit 1
 
 # Start Supervisord
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"] 


### PR DESCRIPTION
Key changes:

- Added new docker-smoke-test.yml workflow that builds and validates both app and worker containers
- Added healthcheck to worker Dockerfile to verify Horizon process status
- Refactored prod-build.yml and dev-build.yml to use matrix strategy for building multiple images
- Added ROR API configuration to .env.example