### PR TITLE
fix(licenses): prevent incomplete class errors from cached models

### DIFF
--- a/app/Http/Controllers/Admin/LicenseController.php
+++ b/app/Http/Controllers/Admin/LicenseController.php
@@ -4,30 +4,60 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\License;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
 class LicenseController extends Controller
 {
     /**
+     * @var list<string>
+     */
+    private const LICENSE_SUMMARY_FIELDS = ['id', 'title', 'description', 'category'];
+
+    /**
      * Return All Licenses
      */
-    public function index(Request $request)
+    public function index(Request $request): JsonResponse
     {
-        $licenses = Cache::rememberForever('licenses', function () {
-            return License::select('id', 'title', 'description', 'category')->orderBy('category', 'ASC')->orderBy('title', 'ASC')->get();
+        $licenses = Cache::rememberForever('licenses', function (): array {
+            return $this->licenseSummaries(
+                License::query()
+                    ->select(self::LICENSE_SUMMARY_FIELDS)
+                    ->orderBy('category')
+                    ->orderBy('title')
+                    ->get()
+            );
         });
 
-        return $licenses;
+        return response()->json($licenses);
     }
 
     /**
      * Return License for particular ID.
      */
-    public function getLicensebyId(Request $request, $id)
+    public function getLicensebyId(Request $request, int $id): JsonResponse
     {
-        $license = License::select('id', 'title', 'description', 'category')->where('id', $id)->get();
+        $license = $this->licenseSummaries(
+            License::query()
+                ->select(self::LICENSE_SUMMARY_FIELDS)
+                ->where('id', $id)
+                ->get()
+        );
 
-        return $license;
+        return response()->json($license);
+    }
+
+    /**
+     * @param  Collection<int, License>  $licenses
+     * @return list<array<string, mixed>>
+     */
+    private function licenseSummaries(Collection $licenses): array
+    {
+        return $licenses
+            ->map(fn (License $license): array => $license->only(self::LICENSE_SUMMARY_FIELDS))
+            ->values()
+            ->all();
     }
 }


### PR DESCRIPTION
## Summary
- Fix `/licenses` TypeError caused by Redis unserializing cached Eloquent collections into `__PHP_Incomplete_Class` under Octane/FrankenPHP
- Cache license summaries as plain arrays instead of model collections
- Return explicit `JsonResponse` objects with typed controller methods and shared field selection

## Test plan
- [x] `php artisan test tests/Feature/Admin/LicenseTest.php`
- [ ] Clear stale cache after deploy: `php artisan cache:forget licenses`
- [ ] Verify `/licenses` loads for authenticated users on study edit pages