### PR TITLE
feat(terminology): migrate ontology autocomplete to TIB API v2

### DIFF
--- a/app/Support/Csp/Policies/NmrxivPolicy.php
+++ b/app/Support/Csp/Policies/NmrxivPolicy.php
@@ -112,7 +112,7 @@ class NmrxivPolicy implements Preset
             ->add(Directive::CONNECT, config('services.chemotion_tracker.base_url'))
             ->add(Directive::CONNECT, config('external-links.cm_api'))
             ->add(Directive::CONNECT, config('filesystems.disks.ceph.endpoint'))
-            ->add(Directive::CONNECT, 'https://service.tib.eu')
+            ->add(Directive::CONNECT, 'https://api.terminology.tib.eu')
             ->add(Directive::CONNECT, 'https://nmrium.nmrxiv.org')
             ->add(Directive::CONNECT, 'https://nmriumdev.nmrxiv.org')
             ->add(Directive::CONNECT, 'https://*.naturalproducts.net')

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
                 "marked": "^4.0.4",
                 "medium-zoom": "^1.0.8",
                 "mitt": "^3.0.0",
-                "ontology-elements": "^0.2.3",
                 "openchemlib": "^9.22.1",
                 "pluralize": "^8.0.0",
                 "popper.js": "^1.16.1",
@@ -3332,9 +3331,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.9",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
-            "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
+            "version": "3.4.12",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -5454,14 +5453,6 @@
                 "emoji-regex-xs": "^1.0.0",
                 "regex": "^6.0.1",
                 "regex-recursion": "^6.0.2"
-            }
-        },
-        "node_modules/ontology-elements": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/ontology-elements/-/ontology-elements-0.2.3.tgz",
-            "integrity": "sha512-7+VBiAveZ8ek3jeGIGOyZPd4y8D7cDWzDwO57+rBnuZXLDaaKIelZ1z/MV0BF/4ghzVl6IGhtkXiRL3LnSeEWA==",
-            "dependencies": {
-                "vue": "^3.2.47"
             }
         },
         "node_modules/openchemlib": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
         "marked": "^4.0.4",
         "medium-zoom": "^1.0.8",
         "mitt": "^3.0.0",
-        "ontology-elements": "^0.2.3",
         "openchemlib": "^9.22.1",
         "pluralize": "^8.0.0",
         "popper.js": "^1.16.1",

--- a/resources/js/Pages/Public/Project/Show.vue
+++ b/resources/js/Pages/Public/Project/Show.vue
@@ -444,7 +444,7 @@ import ProjectDetails from "@/Pages/Project/Partials/Details.vue";
 import Publish from "@/Shared/Publish.vue";
 import Citation from "@/Shared/Citation.vue";
 import Tag from "@/Shared/Tag.vue";
-import "ontology-elements/dist/index.js";
+import "@/lib/ontology-elements";
 import { Head } from "@inertiajs/vue3";
 import { PencilIcon } from "@heroicons/vue/24/solid";
 

--- a/resources/js/Pages/Publish.vue
+++ b/resources/js/Pages/Publish.vue
@@ -1464,7 +1464,7 @@ import {
     UserGroupIcon,
 } from "@heroicons/vue/24/outline";
 import Draggable from "vuedraggable";
-import "ontology-elements/dist/index.js";
+import "@/lib/ontology-elements";
 import JetConfirmationModal from "@/Jetstream/ConfirmationModal.vue";
 import JetSuccessButton from "@/Jetstream/SuccessButton.vue";
 

--- a/resources/js/Pages/Upload.vue
+++ b/resources/js/Pages/Upload.vue
@@ -3594,7 +3594,7 @@ import Depictor from "@/Shared/Depictor.vue";
 import Depictor2D from "@/Shared/Depictor2D.vue";
 import slider from "vue3-slider";
 import VueTagsInput from "@sipec/vue3-tags-input";
-import "ontology-elements/dist/index.js";
+import "@/lib/ontology-elements";
 import Global from "@/Mixins/Global.js";
 import OCL from "openchemlib";
 import { createStructureEditor } from "@/Utils/structureEditor";

--- a/resources/js/lib/ontology-elements/OntologyAutocomplete.ce.vue
+++ b/resources/js/lib/ontology-elements/OntologyAutocomplete.ce.vue
@@ -1,0 +1,240 @@
+<script setup>
+import { computed, onMounted, ref, watch } from "vue";
+
+import { searchOntologyClasses } from "@/lib/terminology-service";
+
+const emit = defineEmits(["change"]);
+
+const props = defineProps({
+    label: {
+        type: String,
+        default: "",
+    },
+    info: {
+        type: String,
+        default: "",
+    },
+    placeholder: {
+        type: String,
+        default: "",
+    },
+    ontologies: {
+        type: String,
+        default: "",
+    },
+    value: {
+        type: String,
+        default: "",
+    },
+    styling: {
+        type: String,
+        default: "",
+    },
+    format: {
+        type: String,
+        default: "text",
+    },
+});
+
+const searchTerm = ref("");
+const matches = ref([]);
+const selectedTerm = ref(null);
+
+const selectedValue = computed(() => {
+    if (!selectedTerm.value) {
+        return null;
+    }
+
+    if (props.format === "json") {
+        return selectedTerm.value;
+    }
+
+    return selectedTerm.value
+        ? `${selectedTerm.value.label}\t${selectedTerm.value.ontology_prefix}\t${selectedTerm.value.iri}\t${selectedTerm.value.type}`
+        : "";
+});
+
+function composeOntologyObject(content) {
+    if (!content) {
+        return "";
+    }
+
+    const data = content.split("\t");
+
+    return {
+        label: data[0],
+        iri: data[2],
+        ontology_prefix: data[1],
+        type: data[3],
+    };
+}
+
+function selectTerm(term) {
+    if (term === "") {
+        selectedTerm.value = null;
+        searchTerm.value = "";
+        return;
+    }
+
+    selectedTerm.value = term;
+    searchTerm.value = term.label;
+    emit("change", selectedValue.value);
+    matches.value = [];
+}
+
+function highlight(content) {
+    if (!searchTerm.value) {
+        return content;
+    }
+
+    return content.replace(
+        new RegExp(searchTerm.value, "gi"),
+        (match) => `<span class="highlightText">${match}</span>`
+    );
+}
+
+function concat(data) {
+    return data ? data.join("") : "";
+}
+
+async function getSelectOptions() {
+    if (searchTerm.value === "") {
+        matches.value = [];
+        return;
+    }
+
+    matches.value = await searchOntologyClasses(
+        searchTerm.value,
+        props.ontologies
+    );
+}
+
+watch(
+    () => props.value,
+    (newValue) => {
+        selectTerm(composeOntologyObject(newValue));
+    }
+);
+
+onMounted(() => {
+    if (props.value !== "") {
+        selectTerm(composeOntologyObject(props.value));
+    }
+});
+</script>
+
+<template>
+    <div class="auto-search-wrapper">
+        <label v-if="label">{{ label }}</label>
+        <input
+            id="search"
+            v-model="searchTerm"
+            type="text"
+            :placeholder="placeholder"
+            :class="styling"
+            autocomplete="off"
+            @input.stop="getSelectOptions"
+        />
+        <p v-if="info && matches.length === 0">{{ info }}</p>
+        <div
+            v-else-if="matches.length > 0"
+            class="auto-results-wrapper auto-is-active"
+        >
+            <ul tabindex="0" role="listbox">
+                <li
+                    v-for="doc in matches"
+                    :key="doc.short_form || doc.iri"
+                    role="option"
+                    tabindex="-1"
+                    aria-selected="false"
+                    @click="selectTerm(doc)"
+                >
+                    <p v-html="highlight(doc.label)"></p>
+                    <p>
+                        <small v-html="concat(doc.description)"></small>
+                    </p>
+                    <small>{{ doc.ontology_prefix }}:{{ doc.iri }}</small>
+                </li>
+            </ul>
+        </div>
+        <button
+            v-if="searchTerm !== '' && matches.length > 0"
+            type="button"
+            aria-label="clear the search query"
+        ></button>
+    </div>
+</template>
+
+<style>
+:root {
+    --close-button: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M18.984 6.422 13.406 12l5.578 5.578-1.406 1.406L12 13.406l-5.578 5.578-1.406-1.406L10.594 12 5.016 6.422l1.406-1.406L12 10.594l5.578-5.578z'/%3E%3C/svg%3E");
+    --loupe-icon: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23929292' d='M16.041 15.856a.995.995 0 0 0-.186.186A6.97 6.97 0 0 1 11 18c-1.933 0-3.682-.782-4.95-2.05S4 12.933 4 11s.782-3.682 2.05-4.95S9.067 4 11 4s3.682.782 4.95 2.05S18 9.067 18 11a6.971 6.971 0 0 1-1.959 4.856zm5.666 4.437-3.675-3.675A8.967 8.967 0 0 0 20 11c0-2.485-1.008-4.736-2.636-6.364S13.485 2 11 2 6.264 3.008 4.636 4.636 2 8.515 2 11s1.008 4.736 2.636 6.364S8.515 20 11 20a8.967 8.967 0 0 0 5.618-1.968l3.675 3.675a.999.999 0 1 0 1.414-1.414z'/%3E%3C/svg%3E");
+}
+
+.auto-search-wrapper {
+    display: block;
+    position: relative;
+    width: 100%;
+}
+
+.auto-search-wrapper p {
+    margin: 0;
+    padding: 0;
+    font-size: 1.1em;
+}
+
+.auto-search-wrapper p .highlightText {
+    font-weight: bold;
+}
+
+.auto-search-wrapper input {
+    border: 1px solid #d7d7d7;
+    box-shadow: none;
+    box-sizing: border-box;
+    font-size: 16px;
+    padding: 12px 45px 12px 10px;
+    width: 100%;
+}
+
+.auto-search-wrapper input:focus {
+    border: 1px solid #858585;
+    outline: none;
+}
+
+.auto-search-wrapper ul {
+    list-style: none;
+    margin: 0;
+    overflow: auto;
+    padding: 0;
+}
+
+.auto-search-wrapper ul li {
+    cursor: pointer;
+    margin: 0;
+    overflow: hidden;
+    padding: 10px;
+    position: relative;
+    border: 1px dotted #f1f1f2;
+}
+
+.auto-search-wrapper ul li:hover {
+    background-color: #f1f1f2;
+}
+
+.auto-results-wrapper {
+    background-color: #fff;
+    border: 1px solid #858585;
+    border-top: none;
+    box-sizing: border-box;
+    display: none;
+    overflow: hidden;
+}
+
+.auto-results-wrapper.auto-is-active {
+    display: block;
+    margin-top: -1px;
+    position: absolute;
+    width: 100%;
+    z-index: 99999;
+}
+</style>

--- a/resources/js/lib/ontology-elements/OntologyTermAnnotation.ce.vue
+++ b/resources/js/lib/ontology-elements/OntologyTermAnnotation.ce.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+    annotation: {
+        type: String,
+        default: "",
+    },
+});
+
+const term = computed(() =>
+    props.annotation ? props.annotation.split("\t")[0] : ""
+);
+const iri = computed(() =>
+    props.annotation ? props.annotation.split("\t")[2] : ""
+);
+const source = computed(() =>
+    props.annotation ? props.annotation.split("\t")[1] : ""
+);
+</script>
+
+<template>
+    <a v-if="annotation && annotation !== ''" :href="iri" target="_blank">
+        {{ source }}: {{ term }}
+    </a>
+</template>

--- a/resources/js/lib/ontology-elements/index.js
+++ b/resources/js/lib/ontology-elements/index.js
@@ -1,0 +1,27 @@
+import { defineCustomElement } from "vue";
+
+import OntologyAutocomplete from "./OntologyAutocomplete.ce.vue";
+import OntologyTermAnnotation from "./OntologyTermAnnotation.ce.vue";
+
+const OntologyAutoCompleteElement = defineCustomElement(OntologyAutocomplete);
+const OntologyTermAnnotationElement = defineCustomElement(
+    OntologyTermAnnotation
+);
+
+if (typeof window !== "undefined") {
+    const { customElements } = window;
+
+    if (!customElements.get("ontology-autocomplete")) {
+        customElements.define(
+            "ontology-autocomplete",
+            OntologyAutoCompleteElement
+        );
+    }
+
+    if (!customElements.get("ontology-term-annotation")) {
+        customElements.define(
+            "ontology-term-annotation",
+            OntologyTermAnnotationElement
+        );
+    }
+}

--- a/resources/js/lib/terminology-service.js
+++ b/resources/js/lib/terminology-service.js
@@ -1,0 +1,98 @@
+const TERMINOLOGY_API_BASE_URL = "https://api.terminology.tib.eu";
+
+function normalizeDescription(element) {
+    const description = element.definition ?? element.description ?? [];
+
+    if (Array.isArray(description)) {
+        return description;
+    }
+
+    return description ? [description] : [];
+}
+
+export function mapClassElementToOntologyDoc(element) {
+    const curie = element.curie ?? "";
+    const colonIndex = curie.indexOf(":");
+
+    return {
+        label: Array.isArray(element.label)
+            ? element.label[0]
+            : element.label ?? "",
+        iri: element.iri ?? "",
+        ontology_prefix:
+            colonIndex > 0
+                ? curie.slice(0, colonIndex)
+                : element.ontologyId ?? "",
+        type: Array.isArray(element.type)
+            ? element.type[0]
+            : element.type ?? "",
+        description: normalizeDescription(element),
+        short_form: curie || element.iri,
+        obo_id: curie,
+    };
+}
+
+function deduplicateByIri(docs) {
+    const seen = new Set();
+
+    return docs.filter((doc) => {
+        if (!doc.iri || seen.has(doc.iri)) {
+            return false;
+        }
+
+        seen.add(doc.iri);
+
+        return true;
+    });
+}
+
+async function fetchClassResults(url) {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+        return [];
+    }
+
+    const data = await response.json();
+
+    return (data.elements ?? []).map(mapClassElementToOntologyDoc);
+}
+
+export async function searchOntologyClasses(searchTerm, ontologies = "") {
+    if (!searchTerm) {
+        return [];
+    }
+
+    let ontologyId = ontologies;
+    let query = searchTerm;
+
+    const colonIndex = searchTerm.indexOf(":");
+    if (colonIndex > 0) {
+        ontologyId = searchTerm.slice(0, colonIndex);
+        query = searchTerm.slice(colonIndex + 1);
+    }
+
+    const params = new URLSearchParams({
+        search: query,
+        page: "0",
+        size: "10",
+        includeObsoleteEntities: "false",
+    });
+
+    if (ontologyId) {
+        const ontologyUrl = `${TERMINOLOGY_API_BASE_URL}/api/v2/ontologies/${encodeURIComponent(
+            ontologyId
+        )}/classes?${params}`;
+        const ontologyResults = await fetchClassResults(ontologyUrl);
+
+        if (ontologyResults.length > 0) {
+            return deduplicateByIri(ontologyResults);
+        }
+    }
+
+    const globalUrl = `${TERMINOLOGY_API_BASE_URL}/api/v2/classes?${params}`;
+
+    return deduplicateByIri(await fetchClassResults(globalUrl));
+}
+
+export { TERMINOLOGY_API_BASE_URL };

--- a/tests/Feature/CspTest.php
+++ b/tests/Feature/CspTest.php
@@ -86,7 +86,7 @@ class CspTest extends TestCase
 
         $policyString = $policy->getContents();
 
-        $this->assertStringContainsString('https://service.tib.eu', $policyString);
+        $this->assertStringContainsString('https://api.terminology.tib.eu', $policyString);
     }
 
     public function test_csp_allows_meilisearch_connections_and_uses_report_uri_from_env(): void

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,15 +7,15 @@
   resolved "https://registry.npmjs.org/@aesoper/normal-utils/-/normal-utils-0.1.5.tgz"
   integrity sha512-LFF/6y6h5mfwhnJaWqqxuC8zzDaHCG62kMRkd8xhDtq62TQj9dM17A9DhE87W7DhiARJsHLgcina/9P4eNCN1w==
 
-"@algolia/abtesting@1.18.1":
-  version "1.18.1"
-  resolved "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.18.1.tgz"
-  integrity sha512-aehCadlWOGvrT91KUIZpC0MbB8KBW9yUuvTJFd2xesR7le/IsT4nJUnjCCZ4ZqZCeTcPHPV5mo//fZ5oxcSVYw==
+"@algolia/abtesting@1.19.0":
+  version "1.19.0"
+  resolved "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.19.0.tgz"
+  integrity sha512-Lhnez3hhXHk25lfxLAMxvkP4fmN3+1RgADhD2ssMDBYuAsDVReeyP+3SGRx+ntq8ijMrLqUyfvO72TB6jsTteQ==
   dependencies:
-    "@algolia/client-common" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
 "@algolia/autocomplete-core@1.17.7":
   version "1.17.7"
@@ -44,161 +44,161 @@
   resolved "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz"
   integrity sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==
 
-"@algolia/client-abtesting@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.52.1.tgz"
-  integrity sha512-HmXOGBOAOJPounpBzBpuY0zDYeiCpxgHnQmuA7JO6ScukcBdGp3/XM9zJk5pJx/xNGD68mbPGXWpDxGtl6BwDQ==
+"@algolia/client-abtesting@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.53.0.tgz"
+  integrity sha512-0ZjA5Hcmaoz5Lj6OG0zhfIyeqzJZnLW2CRJA1W17UwMFGRtZAJ9yJKRvPEDA6gkpsIoQxORTSW6sWFiuYncPNQ==
   dependencies:
-    "@algolia/client-common" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
-"@algolia/client-analytics@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.52.1.tgz"
-  integrity sha512-5oo4+I8iixie9vXhCyNFCzeIr8pqA3FQ//VsLHTDvZAV4ttYOPGvYHGQq5NSalrLx5Jc3dRro/5uDOlnUMcBJg==
+"@algolia/client-analytics@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.53.0.tgz"
+  integrity sha512-kWNodP75iiEaOtemC9F/hlxNBG5E2QUjN1BusnE6m2b4l7Qh/BUO3fGCVsmKJI65VO4VKGGmT43ICvHtTcJ2JQ==
   dependencies:
-    "@algolia/client-common" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
-"@algolia/client-common@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.52.1.tgz"
-  integrity sha512-qCDoZfx5MpX7XQzvQ3bC4tSEMkQWQMaF/ABtLuoze03Y/flR563CCSws02qIJ23oX7lxl92LsilZjINVyTdtLw==
+"@algolia/client-common@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.53.0.tgz"
+  integrity sha512-YPN45TXD9Wrse185t/Ta7nktZsqpv97oOjCzp2sblHnCL6rBc9TDeJAg1IGl2UpdwnSD05Zu/5wLB4watOUMyg==
 
-"@algolia/client-insights@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.52.1.tgz"
-  integrity sha512-hnGs0/lsFJ2PWDxNBz7pxreXo/Xz7gxYRcfePBUjsH26ad0kU/sgnVZd9LwWBpsQv65z2jlb5dkyaB9WE9M9FQ==
+"@algolia/client-insights@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.53.0.tgz"
+  integrity sha512-qAcYTDJE6m924FDDUQvdD6vh7DYaqOeSpFS74IP37/JRV0v4cGBauyxTF2WzDnokUylQDbqreoFIJZfg0Fitmw==
   dependencies:
-    "@algolia/client-common" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
-"@algolia/client-personalization@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.52.1.tgz"
-  integrity sha512-2VxxNc/uBysyKvGeBdSM5n9eIDKH8kWD7wd9/yqbJAiVwU4Yv6tU1LSJusHKrXV/aCu1KW7t9Gug9QyeEmtn/Q==
+"@algolia/client-personalization@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.53.0.tgz"
+  integrity sha512-fQaY+DkSJOpuUVUe8MQTwrdiKAqkJGhpDarB08duBn/sUv7Bkib6MDRQauCcWTWTe4HIW+EbwQP9R4kci1V/Yw==
   dependencies:
-    "@algolia/client-common" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
-"@algolia/client-query-suggestions@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.52.1.tgz"
-  integrity sha512-O6mPtsw3xEfNOe6gWFpYLeAZAIljNa4Hgna3bq15PwyN7nbjTY0wXJFRbzs/0YVf75Br+SbOQUmjKxXYjDiSiQ==
+"@algolia/client-query-suggestions@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.53.0.tgz"
+  integrity sha512-o72tsiEZGfeS/dxL9IADfzcZWGEwKDEe5CvtrBuT//3JR+SHuTtHRI2ZTf7D7bcKagcbojvO8hnkHdfoakSlYg==
   dependencies:
-    "@algolia/client-common" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
-"@algolia/client-search@>= 4.9.1 < 6", "@algolia/client-search@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz"
-  integrity sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==
+"@algolia/client-search@>= 4.9.1 < 6", "@algolia/client-search@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.53.0.tgz"
+  integrity sha512-Ds16IyPm/dNJPCU8OzApo2gwGrgWT5BYHhE3NFwZbpCveqyvPDB9sZDDkJ5DsdOGT2aC+R3i0/M1OVXF2qdgPg==
   dependencies:
-    "@algolia/client-common" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
 "@algolia/events@^4.0.1":
   version "4.0.1"
   resolved "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz"
   integrity sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==
 
-"@algolia/ingestion@1.52.1":
-  version "1.52.1"
-  resolved "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.52.1.tgz"
-  integrity sha512-U9zZfc5xIu9wRxZkt+HceJUAD4VKHKbAyLSloJdEyMRmphXeibfrY9cxqIXBcmPeZzGhn3Imb35Dq8l19PkJhw==
+"@algolia/ingestion@1.53.0":
+  version "1.53.0"
+  resolved "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.53.0.tgz"
+  integrity sha512-oNbT6z4NwD8Pou9VPINGlN/tlG1afESh2EbxqnP6rwl95xKVD/Zlciis1PpNeO/9U/rrajc1+7DcfKi03tX1KQ==
   dependencies:
-    "@algolia/client-common" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
-"@algolia/monitoring@1.52.1":
-  version "1.52.1"
-  resolved "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.52.1.tgz"
-  integrity sha512-a3SGNceHmkQfq77iG8Ka+w1pvwfZa/0lzEIgse30fL0kD+yKnd/dg0dQvSfFPAEt2f21DMcGkDSSeJlO3KdQjQ==
+"@algolia/monitoring@1.53.0":
+  version "1.53.0"
+  resolved "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.53.0.tgz"
+  integrity sha512-G+KZb/yd+qAOFn/cEvTGeLxQm8aP3a0od50l3z/ylccY+/o4YG3TNcjU1tFQHW4mXC137GPyR7W70R0kRQDLnA==
   dependencies:
-    "@algolia/client-common" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
-"@algolia/recommend@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.52.1.tgz"
-  integrity sha512-z98QEguCFDpxb4S/PyrUK1igqF8tPsdbqOUUO6ON91vJ58w+Gwa6ncrI0oNXSFcrkxA5EqPKPQ2A1PBCn08TYQ==
+"@algolia/recommend@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.53.0.tgz"
+  integrity sha512-6aVfYd55Un6IUgPLbo84WfgFZlS3L0vA1ttzXL5vahHewUJ8jYgd89TzlWRTeej7w70mb9RWsVlFYGmJ/diQww==
   dependencies:
-    "@algolia/client-common" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
-"@algolia/requester-browser-xhr@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.52.1.tgz"
-  integrity sha512-CI7+/0I11QeZM59Uc8whd2or0kqzFVjpaPn9Qpwll/krHcBAxk24WkAQ6WX+IwDVMfpont4YGbKwAmCre3vE8Q==
+"@algolia/requester-browser-xhr@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.53.0.tgz"
+  integrity sha512-ke27DqgzCOlt+RbeEdCxtXxMQOnAOi8ujr2wid0DmDKzR95Kw/f9sBsuhBxtjevCqJRJszfRTLY0B1pbO6IhkA==
   dependencies:
-    "@algolia/client-common" "5.52.1"
+    "@algolia/client-common" "5.53.0"
 
-"@algolia/requester-fetch@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.52.1.tgz"
-  integrity sha512-S6bDuw9byfOvm3T71cgdoZgrgnZq6hpdMLkx52Louh57nUAmvGQESz2aojOynQHjbTiV55smvAFbgn0qT4tJrg==
+"@algolia/requester-fetch@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.53.0.tgz"
+  integrity sha512-GngiOqt2Gq4oLno6yXQVj9om+qSO9SWAoduoTOEg79dKZ62brB8OOIvSJG/vDNoanYi6a7Al9uDZwXvi+bcVTg==
   dependencies:
-    "@algolia/client-common" "5.52.1"
+    "@algolia/client-common" "5.53.0"
 
-"@algolia/requester-node-http@5.52.1":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.52.1.tgz"
-  integrity sha512-tqZXM+54rWo4mk5jL5Z/flE11nPmNEdXwFBM5py9DkOmbjeCNemfVd45FyM97XdzfZ0dl9uOJC6PYn1FpkeyQg==
+"@algolia/requester-node-http@5.53.0":
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.53.0.tgz"
+  integrity sha512-6mF9LZMUk0QqWvrnxkxBqhswwz6Xfiwy6/gmTzL5HrlhdVG3ITAqGV2k3XmVThP1h0Ulc3VQwiNCD7/Nr4JNlQ==
   dependencies:
-    "@algolia/client-common" "5.52.1"
+    "@algolia/client-common" "5.53.0"
 
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
-"@babel/helper-string-parser@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz"
-  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
 
-"@babel/helper-validator-identifier@^7.28.5":
-  version "7.28.5"
-  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz"
-  integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
 "@babel/parser@^7.29.3":
-  version "7.29.3"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz"
-  integrity sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==
+  version "7.29.7"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz"
+  integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
   dependencies:
-    "@babel/types" "^7.29.0"
+    "@babel/types" "^7.29.7"
 
 "@babel/runtime@^7.15.4", "@babel/runtime@^7.21.0":
-  version "7.29.2"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz"
-  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+  version "7.29.7"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
-"@babel/types@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz"
-  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
+"@babel/types@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz"
+  integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
   dependencies:
-    "@babel/helper-string-parser" "^7.27.1"
-    "@babel/helper-validator-identifier" "^7.28.5"
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
 
 "@docsearch/css@3.8.2":
   version "3.8.2"
@@ -297,9 +297,9 @@
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
 "@iconify-json/simple-icons@^1.2.21":
-  version "1.2.83"
-  resolved "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.83.tgz"
-  integrity sha512-6Pp9V++XisT9RKH7FB4RLPqUDzcmLtSma0ovOEIoEWGrXtHwBFsH7oN1z8vvCVCb95fb87QgR46/zRLyN9Y3kg==
+  version "1.2.86"
+  resolved "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.86.tgz"
+  integrity sha512-t3jck5qPQuK1qy+bRn9eCoDQhIB7XSazKz1Fjp8hcan3XOAsTI5Mq/s3F0ekOKSvMQqkVORYK6ns6o6T9f5EMA==
   dependencies:
     "@iconify/types" "*"
 
@@ -394,20 +394,20 @@
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@rollup/rollup-darwin-arm64@4.60.4":
-  version "4.60.4"
-  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz"
-  integrity sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==
+"@rollup/rollup-darwin-arm64@4.61.1":
+  version "4.61.1"
+  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz"
+  integrity sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==
 
-"@rollup/rollup-linux-arm64-gnu@4.60.4":
-  version "4.60.4"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz"
-  integrity sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==
+"@rollup/rollup-linux-arm64-gnu@4.61.1":
+  version "4.61.1"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz"
+  integrity sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==
 
-"@rollup/rollup-linux-arm64-musl@4.60.4":
-  version "4.60.4"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz"
-  integrity sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==
+"@rollup/rollup-linux-arm64-musl@4.61.1":
+  version "4.61.1"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz"
+  integrity sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==
 
 "@shikijs/core@^2.1.0", "@shikijs/core@2.5.0":
   version "2.5.0"
@@ -505,33 +505,33 @@
   integrity sha512-pNr0T8LAc3TUx/gxCfQZRe9NB2dPEo/cedPHzUGIPxqDMhgjwNm6jYxww4W5l0zAsAddxr+XfZcqttGiFDgrGg==
 
 "@tailwindcss/typography@^0.5.8":
-  version "0.5.19"
-  resolved "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz"
-  integrity sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==
+  version "0.5.20"
+  resolved "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz"
+  integrity sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==
   dependencies:
     postcss-selector-parser "6.0.10"
 
-"@tanstack/virtual-core@3.14.0":
-  version "3.14.0"
-  resolved "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz"
-  integrity sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==
+"@tanstack/virtual-core@3.17.0":
+  version "3.17.0"
+  resolved "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz"
+  integrity sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==
 
 "@tanstack/vue-virtual@^3.0.0-beta.60":
-  version "3.13.24"
-  resolved "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.24.tgz"
-  integrity sha512-A0k2qF0zFSUStXSZkGXABouXr2Tw2Ztl/cVIYG9qy84uR8W7UNjAcX3DvzBS3YnDcwvLxab8v7dbmYBZ39itDA==
+  version "3.13.28"
+  resolved "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.28.tgz"
+  integrity sha512-A+jWpXtMpWXKhGLKQrXeC9mk1VgYeMWSJ+o0CTCEi+HLYMSQFdVmPG9lJz7d4XJyIkc5xVwZU9QY67QpScqnxA==
   dependencies:
-    "@tanstack/virtual-core" "3.14.0"
+    "@tanstack/virtual-core" "3.17.0"
 
 "@types/dom-speech-recognition@^0.0.1":
   version "0.0.1"
   resolved "https://registry.npmjs.org/@types/dom-speech-recognition/-/dom-speech-recognition-0.0.1.tgz"
   integrity sha512-udCxb8DvjcDKfk1WTBzDsxFbLgYxmQGKrE/ricoMqHRNjSlSUCcamVTA5lIQqzY10mY5qCY0QDwBfFEwhfoDPw==
 
-"@types/estree@^1.0.8", "@types/estree@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
-  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+"@types/estree@^1.0.8", "@types/estree@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
 "@types/google.maps@^3.55.12":
   version "3.65.1"
@@ -586,9 +586,9 @@
   integrity sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
 
 "@types/node@*", "@types/node@^18.0.0 || ^20.0.0 || >=22.0.0":
-  version "25.9.1"
-  resolved "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz"
-  integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
+  version "25.9.2"
+  resolved "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz"
+  integrity sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==
   dependencies:
     undici-types ">=7.24.0 <7.24.7"
 
@@ -639,47 +639,47 @@
   dependencies:
     babel-helper-vue-jsx-merge-props "^2.0.3"
 
-"@vue/compiler-core@3.5.34":
-  version "3.5.34"
-  resolved "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz"
-  integrity sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==
+"@vue/compiler-core@3.5.35":
+  version "3.5.35"
+  resolved "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.35.tgz"
+  integrity sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==
   dependencies:
     "@babel/parser" "^7.29.3"
-    "@vue/shared" "3.5.34"
+    "@vue/shared" "3.5.35"
     entities "^7.0.1"
     estree-walker "^2.0.2"
     source-map-js "^1.2.1"
 
-"@vue/compiler-dom@3.5.34":
-  version "3.5.34"
-  resolved "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz"
-  integrity sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==
+"@vue/compiler-dom@3.5.35":
+  version "3.5.35"
+  resolved "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.35.tgz"
+  integrity sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==
   dependencies:
-    "@vue/compiler-core" "3.5.34"
-    "@vue/shared" "3.5.34"
+    "@vue/compiler-core" "3.5.35"
+    "@vue/shared" "3.5.35"
 
-"@vue/compiler-sfc@^3.0.5", "@vue/compiler-sfc@3.5.34":
-  version "3.5.34"
-  resolved "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz"
-  integrity sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==
+"@vue/compiler-sfc@^3.0.5", "@vue/compiler-sfc@3.5.35":
+  version "3.5.35"
+  resolved "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.35.tgz"
+  integrity sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==
   dependencies:
     "@babel/parser" "^7.29.3"
-    "@vue/compiler-core" "3.5.34"
-    "@vue/compiler-dom" "3.5.34"
-    "@vue/compiler-ssr" "3.5.34"
-    "@vue/shared" "3.5.34"
+    "@vue/compiler-core" "3.5.35"
+    "@vue/compiler-dom" "3.5.35"
+    "@vue/compiler-ssr" "3.5.35"
+    "@vue/shared" "3.5.35"
     estree-walker "^2.0.2"
     magic-string "^0.30.21"
-    postcss "^8.5.14"
+    postcss "^8.5.15"
     source-map-js "^1.2.1"
 
-"@vue/compiler-ssr@3.5.34":
-  version "3.5.34"
-  resolved "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz"
-  integrity sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==
+"@vue/compiler-ssr@3.5.35":
+  version "3.5.35"
+  resolved "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.35.tgz"
+  integrity sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==
   dependencies:
-    "@vue/compiler-dom" "3.5.34"
-    "@vue/shared" "3.5.34"
+    "@vue/compiler-dom" "3.5.35"
+    "@vue/shared" "3.5.35"
 
 "@vue/devtools-api@^7.7.0":
   version "7.7.9"
@@ -708,43 +708,43 @@
   dependencies:
     rfdc "^1.4.1"
 
-"@vue/reactivity@3.5.34":
-  version "3.5.34"
-  resolved "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz"
-  integrity sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==
+"@vue/reactivity@3.5.35":
+  version "3.5.35"
+  resolved "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.35.tgz"
+  integrity sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==
   dependencies:
-    "@vue/shared" "3.5.34"
+    "@vue/shared" "3.5.35"
 
-"@vue/runtime-core@3.5.34":
-  version "3.5.34"
-  resolved "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz"
-  integrity sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==
+"@vue/runtime-core@3.5.35":
+  version "3.5.35"
+  resolved "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.35.tgz"
+  integrity sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==
   dependencies:
-    "@vue/reactivity" "3.5.34"
-    "@vue/shared" "3.5.34"
+    "@vue/reactivity" "3.5.35"
+    "@vue/shared" "3.5.35"
 
-"@vue/runtime-dom@3.5.34":
-  version "3.5.34"
-  resolved "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz"
-  integrity sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==
+"@vue/runtime-dom@3.5.35":
+  version "3.5.35"
+  resolved "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.35.tgz"
+  integrity sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==
   dependencies:
-    "@vue/reactivity" "3.5.34"
-    "@vue/runtime-core" "3.5.34"
-    "@vue/shared" "3.5.34"
+    "@vue/reactivity" "3.5.35"
+    "@vue/runtime-core" "3.5.35"
+    "@vue/shared" "3.5.35"
     csstype "^3.2.3"
 
-"@vue/server-renderer@^3.1.2", "@vue/server-renderer@3.5.34":
-  version "3.5.34"
-  resolved "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz"
-  integrity sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==
+"@vue/server-renderer@^3.1.2", "@vue/server-renderer@3.5.35":
+  version "3.5.35"
+  resolved "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.35.tgz"
+  integrity sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==
   dependencies:
-    "@vue/compiler-ssr" "3.5.34"
-    "@vue/shared" "3.5.34"
+    "@vue/compiler-ssr" "3.5.35"
+    "@vue/shared" "3.5.35"
 
-"@vue/shared@^3.5.13", "@vue/shared@3.5.34":
-  version "3.5.34"
-  resolved "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz"
-  integrity sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==
+"@vue/shared@^3.5.13", "@vue/shared@3.5.35":
+  version "3.5.35"
+  resolved "https://registry.npmjs.org/@vue/shared/-/shared-3.5.35.tgz"
+  integrity sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==
 
 "@vuepic/vue-datepicker@^3.3.1":
   version "3.6.8"
@@ -1029,24 +1029,24 @@ algoliasearch-helper@3.29.1:
     "@algolia/events" "^4.0.1"
 
 algoliasearch@^5.14.2, "algoliasearch@>= 3.1 < 6", "algoliasearch@>= 3.32.0 < 6", "algoliasearch@>= 4.9.1 < 6":
-  version "5.52.1"
-  resolved "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz"
-  integrity sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==
+  version "5.53.0"
+  resolved "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.53.0.tgz"
+  integrity sha512-OGW1q6b91CRSSeiOnM8LxuR5NYJ2esvw66jUZ4IIvdv+ItNkx3pwLuyR+jaCdbGee4ov5WgUnyPryyh11xvByQ==
   dependencies:
-    "@algolia/abtesting" "1.18.1"
-    "@algolia/client-abtesting" "5.52.1"
-    "@algolia/client-analytics" "5.52.1"
-    "@algolia/client-common" "5.52.1"
-    "@algolia/client-insights" "5.52.1"
-    "@algolia/client-personalization" "5.52.1"
-    "@algolia/client-query-suggestions" "5.52.1"
-    "@algolia/client-search" "5.52.1"
-    "@algolia/ingestion" "1.52.1"
-    "@algolia/monitoring" "1.52.1"
-    "@algolia/recommend" "5.52.1"
-    "@algolia/requester-browser-xhr" "5.52.1"
-    "@algolia/requester-fetch" "5.52.1"
-    "@algolia/requester-node-http" "5.52.1"
+    "@algolia/abtesting" "1.19.0"
+    "@algolia/client-abtesting" "5.53.0"
+    "@algolia/client-analytics" "5.53.0"
+    "@algolia/client-common" "5.53.0"
+    "@algolia/client-insights" "5.53.0"
+    "@algolia/client-personalization" "5.53.0"
+    "@algolia/client-query-suggestions" "5.53.0"
+    "@algolia/client-search" "5.53.0"
+    "@algolia/ingestion" "1.53.0"
+    "@algolia/monitoring" "1.53.0"
+    "@algolia/recommend" "5.53.0"
+    "@algolia/requester-browser-xhr" "5.53.0"
+    "@algolia/requester-fetch" "5.53.0"
+    "@algolia/requester-node-http" "5.53.0"
 
 ansi-escapes@^7.0.0:
   version "7.3.0"
@@ -1130,9 +1130,9 @@ axios-retry@^3.2.5:
     is-retry-allowed "^2.2.0"
 
 axios@^1, axios@^1.6.0, axios@^1.8.2:
-  version "1.16.1"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz"
-  integrity sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==
+  version "1.17.0"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz"
+  integrity sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==
   dependencies:
     follow-redirects "^1.16.0"
     form-data "^4.0.5"
@@ -1150,9 +1150,9 @@ balanced-match@^1.0.0:
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.31"
-  resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz"
-  integrity sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==
+  version "2.10.35"
+  resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz"
+  integrity sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -1175,9 +1175,9 @@ boolbase@^1.0.0:
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 brace-expansion@^1.1.7:
-  version "1.1.14"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz"
-  integrity sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==
+  version "1.1.15"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz"
+  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -1232,9 +1232,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001782, caniuse-lite@^1.0.30001787:
-  version "1.0.30001793"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz"
-  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
+  version "1.0.30001797"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz"
+  integrity sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -1485,9 +1485,9 @@ doctrine@^3.0.0:
     esutils "^2.0.2"
 
 dompurify@^3.0.5:
-  version "3.4.5"
-  resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz"
-  integrity sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==
+  version "3.4.12"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz"
+  integrity sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
@@ -1509,9 +1509,9 @@ dunder-proto@^1.0.1:
     gopd "^1.2.0"
 
 electron-to-chromium@^1.5.328:
-  version "1.5.360"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz"
-  integrity sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==
+  version "1.5.371"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz"
+  integrity sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==
 
 emoji-regex-xs@^1.0.0:
   version "1.0.0"
@@ -1533,10 +1533,10 @@ emojis-list@^3.0.0:
   resolved "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-enhanced-resolve@^5.21.4:
-  version "5.21.5"
-  resolved "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.5.tgz"
-  integrity sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A==
+enhanced-resolve@^5.22.0:
+  version "5.23.0"
+  resolved "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz"
+  integrity sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.3.3"
@@ -1567,9 +1567,9 @@ es-module-lexer@^2.1.0:
   integrity sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz"
-  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
   dependencies:
     es-errors "^1.3.0"
 
@@ -2220,9 +2220,9 @@ jiti@^1.21.7, jiti@>=1.21.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 
@@ -2579,9 +2579,9 @@ node-fetch@^2.7.0:
     whatwg-url "^5.0.0"
 
 node-releases@^2.0.36:
-  version "2.0.44"
-  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz"
-  integrity sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==
+  version "2.0.47"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz"
+  integrity sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==
 
 nopt@1.0.10:
   version "1.0.10"
@@ -2644,13 +2644,6 @@ oniguruma-to-es@^3.1.0:
     emoji-regex-xs "^1.0.0"
     regex "^6.0.1"
     regex-recursion "^6.0.2"
-
-ontology-elements@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/ontology-elements/-/ontology-elements-0.2.3.tgz"
-  integrity sha512-7+VBiAveZ8ek3jeGIGOyZPd4y8D7cDWzDwO57+rBnuZXLDaaKIelZ1z/MV0BF/4ghzVl6IGhtkXiRL3LnSeEWA==
-  dependencies:
-    vue "^3.2.47"
 
 openchemlib@^9.22.1:
   version "9.22.1"
@@ -2836,7 +2829,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8, postcss@^8.0.0, postcss@^8.1.0, postcss@^8.2.14, postcss@^8.4.19, postcss@^8.4.21, postcss@^8.4.47, postcss@^8.5.14, postcss@^8.5.3, postcss@>=8.0.9:
+postcss@^8, postcss@^8.0.0, postcss@^8.1.0, postcss@^8.2.14, postcss@^8.4.19, postcss@^8.4.21, postcss@^8.4.47, postcss@^8.5.15, postcss@^8.5.3, postcss@>=8.0.9:
   version "8.5.15"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz"
   integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
@@ -2861,9 +2854,9 @@ prettier@2.7.1:
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 property-information@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz"
-  integrity sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz"
+  integrity sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==
 
 proxy-from-env@^2.1.0:
   version "2.1.0"
@@ -2980,37 +2973,37 @@ rimraf@^3.0.2:
     glob "^7.1.3"
 
 rollup@^4.34.9:
-  version "4.60.4"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz"
-  integrity sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==
+  version "4.61.1"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz"
+  integrity sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==
   dependencies:
-    "@types/estree" "1.0.8"
+    "@types/estree" "1.0.9"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.60.4"
-    "@rollup/rollup-android-arm64" "4.60.4"
-    "@rollup/rollup-darwin-arm64" "4.60.4"
-    "@rollup/rollup-darwin-x64" "4.60.4"
-    "@rollup/rollup-freebsd-arm64" "4.60.4"
-    "@rollup/rollup-freebsd-x64" "4.60.4"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.60.4"
-    "@rollup/rollup-linux-arm-musleabihf" "4.60.4"
-    "@rollup/rollup-linux-arm64-gnu" "4.60.4"
-    "@rollup/rollup-linux-arm64-musl" "4.60.4"
-    "@rollup/rollup-linux-loong64-gnu" "4.60.4"
-    "@rollup/rollup-linux-loong64-musl" "4.60.4"
-    "@rollup/rollup-linux-ppc64-gnu" "4.60.4"
-    "@rollup/rollup-linux-ppc64-musl" "4.60.4"
-    "@rollup/rollup-linux-riscv64-gnu" "4.60.4"
-    "@rollup/rollup-linux-riscv64-musl" "4.60.4"
-    "@rollup/rollup-linux-s390x-gnu" "4.60.4"
-    "@rollup/rollup-linux-x64-gnu" "4.60.4"
-    "@rollup/rollup-linux-x64-musl" "4.60.4"
-    "@rollup/rollup-openbsd-x64" "4.60.4"
-    "@rollup/rollup-openharmony-arm64" "4.60.4"
-    "@rollup/rollup-win32-arm64-msvc" "4.60.4"
-    "@rollup/rollup-win32-ia32-msvc" "4.60.4"
-    "@rollup/rollup-win32-x64-gnu" "4.60.4"
-    "@rollup/rollup-win32-x64-msvc" "4.60.4"
+    "@rollup/rollup-android-arm-eabi" "4.61.1"
+    "@rollup/rollup-android-arm64" "4.61.1"
+    "@rollup/rollup-darwin-arm64" "4.61.1"
+    "@rollup/rollup-darwin-x64" "4.61.1"
+    "@rollup/rollup-freebsd-arm64" "4.61.1"
+    "@rollup/rollup-freebsd-x64" "4.61.1"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.61.1"
+    "@rollup/rollup-linux-arm-musleabihf" "4.61.1"
+    "@rollup/rollup-linux-arm64-gnu" "4.61.1"
+    "@rollup/rollup-linux-arm64-musl" "4.61.1"
+    "@rollup/rollup-linux-loong64-gnu" "4.61.1"
+    "@rollup/rollup-linux-loong64-musl" "4.61.1"
+    "@rollup/rollup-linux-ppc64-gnu" "4.61.1"
+    "@rollup/rollup-linux-ppc64-musl" "4.61.1"
+    "@rollup/rollup-linux-riscv64-gnu" "4.61.1"
+    "@rollup/rollup-linux-riscv64-musl" "4.61.1"
+    "@rollup/rollup-linux-s390x-gnu" "4.61.1"
+    "@rollup/rollup-linux-x64-gnu" "4.61.1"
+    "@rollup/rollup-linux-x64-musl" "4.61.1"
+    "@rollup/rollup-openbsd-x64" "4.61.1"
+    "@rollup/rollup-openharmony-arm64" "4.61.1"
+    "@rollup/rollup-win32-arm64-msvc" "4.61.1"
+    "@rollup/rollup-win32-ia32-msvc" "4.61.1"
+    "@rollup/rollup-win32-x64-gnu" "4.61.1"
+    "@rollup/rollup-win32-x64-msvc" "4.61.1"
     fsevents "~2.3.2"
 
 run-parallel@^1.1.9:
@@ -3048,9 +3041,9 @@ select@^1.1.2:
   integrity sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==
 
 semver@^7.3.6, semver@^7.6.3:
-  version "7.8.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz"
-  integrity sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==
+  version "7.8.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz"
+  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -3083,7 +3076,7 @@ shiki@^2.1.0:
     "@shikijs/vscode-textmate" "^10.0.2"
     "@types/hast" "^3.0.4"
 
-side-channel-list@^1.0.0:
+side-channel-list@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz"
   integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
@@ -3113,13 +3106,13 @@ side-channel-weakmap@^1.0.2:
     side-channel-map "^1.0.1"
 
 side-channel@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz"
-  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
   dependencies:
     es-errors "^1.3.0"
-    object-inspect "^1.13.3"
-    side-channel-list "^1.0.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
@@ -3300,7 +3293,7 @@ tailwindcss-bg-patterns@^0.3.0:
   resolved "https://registry.npmjs.org/tailwindcss-bg-patterns/-/tailwindcss-bg-patterns-0.3.0.tgz"
   integrity sha512-3pXCiu9MPBvfBAEYgrxpNZLZoDlVHdkofpuQ9uhVQ2RT+80BTTweL9s0uIvakfH2LRl4GCG+nncyCB+1aN1gpA==
 
-tailwindcss@^3.4.18, "tailwindcss@>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1", "tailwindcss@>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1", "tailwindcss@>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1", tailwindcss@>2:
+tailwindcss@^3.4.18, "tailwindcss@>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1", "tailwindcss@>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1", "tailwindcss@>=3.0.0 || >=4.0.0 || insiders", tailwindcss@>2:
   version "3.4.19"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz"
   integrity sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==
@@ -3334,9 +3327,9 @@ tapable@^2.3.0, tapable@^2.3.3:
   integrity sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==
 
 terser-webpack-plugin@^5.5.0:
-  version "5.6.0"
-  resolved "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz"
-  integrity sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==
+  version "5.6.1"
+  resolved "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz"
+  integrity sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.25"
     jest-worker "^27.4.5"
@@ -3344,9 +3337,9 @@ terser-webpack-plugin@^5.5.0:
     terser "^5.31.1"
 
 terser@^5.16.0, terser@^5.31.1:
-  version "5.47.1"
-  resolved "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz"
-  integrity sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==
+  version "5.48.0"
+  resolved "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz"
+  integrity sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.15.0"
@@ -3383,14 +3376,14 @@ tinycolor2@^1.4.2:
   integrity sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==
 
 tinyexec@^1.0.4:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz"
-  integrity sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz"
+  integrity sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==
 
 tinyglobby@^0.2.11, tinyglobby@^0.2.13:
-  version "0.2.16"
-  resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz"
-  integrity sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
+  version "0.2.17"
+  resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.4"
@@ -3620,16 +3613,16 @@ vue-types@^4.1.0:
   dependencies:
     is-plain-object "5.0.0"
 
-"vue@^2.0.0 || ^3.0.0", "vue@^2.6.0 || ^3.2.0", "vue@^2.6.0 || >=3.0.0-rc.0", "vue@^2.7.0 || ^3.0.0", vue@^3.0.0, "vue@^3.0.0-0 || ^2.6.0", vue@^3.0.0-beta.1, vue@^3.0.1, vue@^3.0.5, vue@^3.2.0, vue@^3.2.25, vue@^3.2.31, vue@^3.2.47, vue@^3.2.6, vue@^3.3.4, vue@^3.5.13, "vue@>= 3", vue@>=3.2.0, vue@3.5.34:
-  version "3.5.34"
-  resolved "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz"
-  integrity sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==
+"vue@^2.0.0 || ^3.0.0", "vue@^2.6.0 || ^3.2.0", "vue@^2.6.0 || >=3.0.0-rc.0", "vue@^2.7.0 || ^3.0.0", vue@^3.0.0, "vue@^3.0.0-0 || ^2.6.0", vue@^3.0.0-beta.1, vue@^3.0.1, vue@^3.0.5, vue@^3.2.0, vue@^3.2.25, vue@^3.2.31, vue@^3.2.6, vue@^3.3.4, vue@^3.5.13, "vue@>= 3", vue@>=3.2.0, vue@3.5.35:
+  version "3.5.35"
+  resolved "https://registry.npmjs.org/vue/-/vue-3.5.35.tgz"
+  integrity sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==
   dependencies:
-    "@vue/compiler-dom" "3.5.34"
-    "@vue/compiler-sfc" "3.5.34"
-    "@vue/runtime-dom" "3.5.34"
-    "@vue/server-renderer" "3.5.34"
-    "@vue/shared" "3.5.34"
+    "@vue/compiler-dom" "3.5.35"
+    "@vue/compiler-sfc" "3.5.35"
+    "@vue/runtime-dom" "3.5.35"
+    "@vue/server-renderer" "3.5.35"
+    "@vue/shared" "3.5.35"
 
 vue3-clipboard@^1.0.0:
   version "1.0.0"
@@ -3685,15 +3678,15 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
-webpack-sources@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz"
-  integrity sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==
+webpack-sources@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz"
+  integrity sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==
 
 "webpack@^4.1.0 || ^5.0.0-0", webpack@^5.1.0:
-  version "5.107.0"
-  resolved "https://registry.npmjs.org/webpack/-/webpack-5.107.0.tgz"
-  integrity sha512-PSxeHk/dmLYZlnTU+vL1Gej6Evg5RNtl3flhxBresfznFnzxinHMzHKloHnywM/3ouQv7/AlZCswWDIkNSggUA==
+  version "5.107.2"
+  resolved "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz"
+  integrity sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==
   dependencies:
     "@types/estree" "^1.0.8"
     "@types/json-schema" "^7.0.15"
@@ -3704,7 +3697,7 @@ webpack-sources@^3.4.1:
     acorn-import-phases "^1.0.3"
     browserslist "^4.28.1"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.21.4"
+    enhanced-resolve "^5.22.0"
     es-module-lexer "^2.1.0"
     eslint-scope "5.1.1"
     events "^3.2.0"
@@ -3717,7 +3710,7 @@ webpack-sources@^3.4.1:
     tapable "^2.3.0"
     terser-webpack-plugin "^5.5.0"
     watchpack "^2.5.1"
-    webpack-sources "^3.4.1"
+    webpack-sources "^3.5.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary

- Replace the archived `ontology-elements` npm package, which called the deprecated `https://service.tib.eu/ts4tib/api` endpoint, with local web components backed by the [TIB Terminology Service v2 API](https://api.terminology.tib.eu/).
- Add a `terminology-service` client that queries `/api/v2/classes` and maps OLS4 responses to the tab-separated annotation format used by existing upload/publish flows.
- Update CSP `connect-src` to allow `https://api.terminology.tib.eu` so browser-side ontology searches are not blocked.

## Test plan

- [ ] Run `npm install` and `npm run dev` (or `npm run build`) to compile the new local ontology components
- [ ] On Upload and Publish, search for a species term (e.g. "Homo sapiens") and confirm autocomplete suggestions appear
- [ ] Select a term and verify the annotation badge renders with the correct label and ontology link
- [ ] On a public project page with species metadata, confirm `ontology-term-annotation` links still render correctly
- [ ] Run `php artisan test tests/Feature/CspTest.php --no-coverage` and confirm CSP tests pass