### PR TITLE
fix(ui): render molecular formula numbers as subscripts

### DIFF
--- a/resources/js/App/MoleculeCard.vue
+++ b/resources/js/App/MoleculeCard.vue
@@ -106,7 +106,9 @@
                                 <dd
                                     class="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 font-mono text-[11px] font-medium text-gray-800 dark:bg-gray-800/80 dark:text-gray-200"
                                 >
-                                    {{ molecularFormula }}
+                                    <MolecularFormula
+                                        :formula="molecularFormula"
+                                    />
                                 </dd>
                             </template>
                             <span
@@ -230,10 +232,12 @@
 </template>
 <script>
 import Depictor2D from "@/Shared/Depictor2D.vue";
+import MolecularFormula from "@/Shared/MolecularFormula.vue";
 import { Link as InertiaLink } from "@inertiajs/vue3";
 export default {
     components: {
         Depictor2D,
+        MolecularFormula,
         InertiaLink,
     },
     props: {

--- a/resources/js/Pages/Public/Studies.vue
+++ b/resources/js/Pages/Public/Studies.vue
@@ -82,10 +82,13 @@
                                                         Molecular Formula:
                                                         <span
                                                             class="text-base inline font-semibold text-gray-900"
-                                                            >{{
-                                                                molecule.molecular_formula
-                                                            }}</span
                                                         >
+                                                            <MolecularFormula
+                                                                :formula="
+                                                                    molecule.molecular_formula
+                                                                "
+                                                            />
+                                                        </span>
                                                     </a>
                                                     &emsp; &middot; &emsp;
                                                     <a>
@@ -417,6 +420,7 @@
 
 <script>
 import AppLayout from "@/Layouts/AppLayout.vue";
+import MolecularFormula from "@/Shared/MolecularFormula.vue";
 import StudySearch from "@/Shared/StudySearch.vue";
 import StudyPublicCard from "@/Shared/StudyCardPublic.vue";
 import { ref } from "vue";
@@ -433,6 +437,7 @@ import {
 export default {
     components: {
         AppLayout,
+        MolecularFormula,
         StudySearch,
         Pagination,
         Menu,

--- a/resources/js/Shared/MolecularFormula.vue
+++ b/resources/js/Shared/MolecularFormula.vue
@@ -1,0 +1,29 @@
+<template>
+    <span class="inline">
+        <template v-for="(part, index) in parts" :key="index">
+            <sub v-if="part.subscript">{{ part.text }}</sub>
+            <template v-else>{{ part.text }}</template>
+        </template>
+    </span>
+</template>
+
+<script>
+import { parseMolecularFormulaDisplayParts } from "@/Utils/molecularFormula.js";
+
+export default {
+    name: "MolecularFormula",
+
+    props: {
+        formula: {
+            type: String,
+            required: true,
+        },
+    },
+
+    computed: {
+        parts() {
+            return parseMolecularFormulaDisplayParts(this.formula);
+        },
+    },
+};
+</script>

--- a/resources/js/Shared/MolecularInfoPanel.vue
+++ b/resources/js/Shared/MolecularInfoPanel.vue
@@ -36,7 +36,11 @@
                                 : 'text-sm font-medium tabular-nums',
                         ]"
                     >
-                        {{ field.value }}
+                        <MolecularFormula
+                            v-if="field.formula"
+                            :formula="field.value"
+                        />
+                        <template v-else>{{ field.value }}</template>
                     </dd>
                 </div>
             </dl>
@@ -55,12 +59,14 @@
 
 <script>
 import Depictor2D from "@/Shared/Depictor2D.vue";
+import MolecularFormula from "@/Shared/MolecularFormula.vue";
 
 export default {
     name: "MolecularInfoPanel",
 
     components: {
         Depictor2D,
+        MolecularFormula,
     },
 
     props: {
@@ -133,6 +139,7 @@ export default {
                     label: "Molecular formula",
                     value: String(formula).trim(),
                     mono: true,
+                    formula: true,
                 });
             }
 

--- a/resources/js/Utils/molecularFormula.js
+++ b/resources/js/Utils/molecularFormula.js
@@ -1,0 +1,46 @@
+/**
+ * @param {string|null|undefined} formula
+ * @returns {{ text: string, subscript: boolean }[]}
+ */
+export function parseMolecularFormulaDisplayParts(formula) {
+    if (formula == null) {
+        return [];
+    }
+
+    const plain = String(formula)
+        .replace(/<[^>]*>/g, "")
+        .trim();
+
+    if (plain === "") {
+        return [];
+    }
+
+    const parts = [];
+    const regex = /(\d+)/g;
+    let lastIndex = 0;
+    let match;
+
+    while ((match = regex.exec(plain)) !== null) {
+        if (match.index > lastIndex) {
+            parts.push({
+                text: plain.slice(lastIndex, match.index),
+                subscript: false,
+            });
+        }
+
+        parts.push({
+            text: match[1],
+            subscript: true,
+        });
+        lastIndex = regex.lastIndex;
+    }
+
+    if (lastIndex < plain.length) {
+        parts.push({
+            text: plain.slice(lastIndex),
+            subscript: false,
+        });
+    }
+
+    return parts;
+}


### PR DESCRIPTION
## Summary

- Adds a shared `MolecularFormula` Vue component and `parseMolecularFormulaDisplayParts` utility to render molecular formula counts as subscripts (e.g. C<sub>9</sub>H<sub>8</sub>O<sub>4</sub>).
- Updates all user-facing molecule views that display molecular formulas: sample/dataset/study sidebars (`MolecularInfoPanel`), molecule cards (`MoleculeCard`), and the public studies header (`Public/Studies`).

Closes #1432

## Test plan

- [ ] Open a public sample page with molecular info in the sidebar and confirm formula numbers render as subscripts
- [ ] Open a molecule card listing (e.g. dashboard compounds) and confirm subscript formatting
- [ ] Open a public studies page for a molecule and confirm the header molecular formula uses subscripts
- [ ] Verify formulas that previously included HTML from CAS (e.g. `CH<sub>2</sub>O`) still render correctly after tag stripping