### PR TITLE
feat(hifsa): add 3D assignment viewer and public HiFSA panels

### DIFF
--- a/app/Http/Controllers/StudyController.php
+++ b/app/Http/Controllers/StudyController.php
@@ -198,7 +198,7 @@ class StudyController extends Controller
                 break;
             case 'Datasets':
                 return Inertia::render('Study/Datasets', [
-                    'study' => $study->load('users', 'owner', 'studyInvitations', 'datasets'),
+                    'study' => $study->load('users', 'owner', 'studyInvitations', 'datasets', 'sample.molecules'),
                     'team' => $team ? $team->load('users', 'owner') : null,
                     'project' => $project ? $project->load('users', 'owner') : null,
                     'members' => $study->allUsers(),

--- a/app/Http/Resources/StudyResource.php
+++ b/app/Http/Resources/StudyResource.php
@@ -56,6 +56,7 @@ class StudyResource extends JsonResource
             'external_id' => $this->external_id,
             'external_url' => $this->external_url,
             'processing_logs' => $this->processing_logs,
+            'hifsa_data' => $this->when(! $this->lite, fn () => $this->hifsa_data),
             'stats' => [
                 'likes' => $this->likesCount(),
                 'views' => (int) $this->views,

--- a/app/Support/Draft/HifsaPdfResolver.php
+++ b/app/Support/Draft/HifsaPdfResolver.php
@@ -107,7 +107,9 @@ class HifsaPdfResolver
      *     chemical_shifts: list<array<string, mixed>>,
      *     couplings: list<array<string, mixed>>,
      *     lineshapes: list<array<string, mixed>>,
-     *     qmgi: list<array<string, mixed>>
+     *     qmgi: list<array<string, mixed>>,
+     *     structures?: array<string, string>,
+     *     atom_maps?: array<string, array<string, int>>
      * }|null
      */
     public function readCsvData(FileSystemObject $zipFile): ?array
@@ -203,6 +205,8 @@ class HifsaPdfResolver
                 }
 
                 $this->enrichFromRefCsvs($zip, $parsed);
+                $parsed['structures'] = $this->extractSpinSystemStructures($zip);
+                $parsed['atom_maps'] = $this->extractAtomMaps($zip);
 
                 return $parsed;
             } finally {
@@ -655,7 +659,7 @@ class HifsaPdfResolver
             'nucleus' => $this->toFloat($row['Nucleus'] ?? null),
             'spincount' => $this->toFloat($row['Spincount'] ?? null),
             'nucleicount' => $this->toFloat($row['Nucleicount'] ?? null),
-            'shift' => $this->toFloat($row['Shift'] ?? null),
+            'shift' => $this->toDisplayableShiftPpm($row['Shift'] ?? null),
             'response' => $this->toFloat($row['Response'] ?? null),
             'line_shape' => $this->nullableString($row['Line shape'] ?? null),
             'lrms' => $this->toNullableFiniteFloat($row['LRMS'] ?? null),
@@ -687,7 +691,7 @@ class HifsaPdfResolver
             'name' => $this->nullableString($this->cellByHeader($header, $cells, 'Name')),
             'shift_from' => $this->nullableString($cells[$shiftIndexes[0] ?? -1] ?? null),
             'shift_to' => $this->nullableString($cells[$shiftIndexes[1] ?? -1] ?? null),
-            'coupling' => $this->toFloat($this->cellByHeader($header, $cells, 'Coupling')),
+            'coupling' => $this->toDisplayableCouplingHz($this->cellByHeader($header, $cells, 'Coupling')),
         ];
     }
 
@@ -823,6 +827,34 @@ class HifsaPdfResolver
     }
 
     /**
+     * Cosmic Truth unset chemical shifts use huge sentinels (e.g. -1e12).
+     */
+    private function toDisplayableShiftPpm(mixed $value): ?float
+    {
+        $float = $this->toFloat($value);
+
+        if ($float === null || ! is_finite($float) || abs($float) >= 1000) {
+            return null;
+        }
+
+        return $float;
+    }
+
+    /**
+     * Reject non-physical / sentinel coupling constants.
+     */
+    private function toDisplayableCouplingHz(mixed $value): ?float
+    {
+        $float = $this->toFloat($value);
+
+        if ($float === null || ! is_finite($float) || abs($float) >= 1e6) {
+            return null;
+        }
+
+        return $float;
+    }
+
+    /**
      * Like toFloat, but also rejects Cosmic Truth ND sentinels (-1, ±Infinity).
      */
     private function toNullableFiniteFloat(mixed $value): ?float
@@ -845,9 +877,9 @@ class HifsaPdfResolver
     }
 
     /**
-     * True when hifsa_data already has scores and the section arrays introduced
-     * for the detail tables. Score-only payloads from earlier parses are treated
-     * as incomplete so they get upgraded from the export zip.
+     * True when hifsa_data already has scores, section arrays, and non-empty
+     * CT structures + atom maps. Empty maps/structures are incomplete so a
+     * later export with OUTPUT.json / spinsystems.sdf can upgrade the study.
      */
     private function hasStructuredHifsaData(mixed $data): bool
     {
@@ -855,13 +887,149 @@ class HifsaPdfResolver
             return false;
         }
 
-        foreach (['spinsystems', 'chemical_shifts', 'couplings', 'lineshapes', 'qmgi'] as $key) {
+        foreach (['spinsystems', 'chemical_shifts', 'couplings', 'lineshapes', 'qmgi', 'structures', 'atom_maps'] as $key) {
             if (! array_key_exists($key, $data) || ! is_array($data[$key])) {
                 return false;
             }
         }
 
+        if ($data['structures'] === [] || $data['atom_maps'] === []) {
+            return false;
+        }
+
         return true;
+    }
+
+    /**
+     * Extract Cosmic Truth `spinsystems.sdf` (true 3D conformers) keyed by
+     * spin-system name / SDF title line.
+     *
+     * @return array<string, string>
+     */
+    private function extractSpinSystemStructures(ZipArchive $zip): array
+    {
+        $sdfName = null;
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $name = $zip->getNameIndex($i);
+
+            if (! is_string($name)) {
+                continue;
+            }
+
+            if (strcasecmp(basename($name), 'spinsystems.sdf') === 0) {
+                $sdfName = $name;
+                break;
+            }
+        }
+
+        if ($sdfName === null) {
+            return [];
+        }
+
+        $contents = $zip->getFromName($sdfName);
+
+        if ($contents === false || trim($contents) === '') {
+            return [];
+        }
+
+        $structures = [];
+
+        foreach (preg_split('/\$\$\$\$\s*/', $contents) ?: [] as $block) {
+            $block = trim($block);
+
+            if ($block === '') {
+                continue;
+            }
+
+            $lines = preg_split('/\r\n|\r|\n/', $block) ?: [];
+            $title = trim((string) ($lines[0] ?? ''));
+
+            if ($title === '') {
+                continue;
+            }
+
+            if (! str_contains($block, 'M  END') && ! str_contains($block, 'M END')) {
+                continue;
+            }
+
+            $structures[$title] = $block."\n".'$$$$'."\n";
+        }
+
+        return $structures;
+    }
+
+    /**
+     * Build Cosmic Truth atom-name → 1-based SDF index maps from OUTPUT.json.
+     *
+     * CT labels like C34 / H4 are NOT SDF serials. Each atom entry has `n`
+     * (label) and `o` (0-based order in the mol/SDF); use o+1 as the SDF index.
+     *
+     * @return array<string, array<string, int>>
+     */
+    private function extractAtomMaps(ZipArchive $zip): array
+    {
+        $maps = [];
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $name = $zip->getNameIndex($i);
+
+            if (! is_string($name)) {
+                continue;
+            }
+
+            if (! preg_match('/_OUTPUT\.json$/i', $name)) {
+                continue;
+            }
+
+            $contents = $zip->getFromName($name);
+
+            if ($contents === false || trim($contents) === '') {
+                continue;
+            }
+
+            $json = json_decode($contents, true);
+
+            if (! is_array($json)) {
+                continue;
+            }
+
+            $spinSystem = trim((string) ($json['n'] ?? ''));
+            $atoms = $json['a'] ?? null;
+
+            if ($spinSystem === '' || ! is_array($atoms)) {
+                continue;
+            }
+
+            $map = [];
+
+            foreach ($atoms as $atom) {
+                if (! is_array($atom)) {
+                    continue;
+                }
+
+                $label = trim((string) ($atom['n'] ?? ''));
+                $order = $atom['o'] ?? null;
+
+                if ($label === '' || ! is_numeric($order)) {
+                    continue;
+                }
+
+                $index = ((int) $order) + 1;
+
+                if ($index < 1) {
+                    continue;
+                }
+
+                $map[$label] = $index;
+            }
+
+            if ($map !== []) {
+                $maps[$spinSystem] = $map;
+            }
+        }
+
+        return $maps;
     }
 
     /**

--- a/app/Support/Hifsa/HifsaAtomLabels.php
+++ b/app/Support/Hifsa/HifsaAtomLabels.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Support\Hifsa;
+
+/**
+ * Parse Cosmic Truth / HiFSA atom labels (H14, C10,C11) and pair coupling endpoints.
+ */
+class HifsaAtomLabels
+{
+    /**
+     * Split a Cosmic Truth atom name into individual atom descriptors.
+     *
+     * @return list<array{element: string, serial: int, suffix: ?string, raw: string}>
+     */
+    public static function parseGroup(?string $name): array
+    {
+        if ($name === null || trim($name) === '') {
+            return [];
+        }
+
+        $parts = preg_split('/\s*,\s*/', trim($name)) ?: [];
+        $atoms = [];
+
+        foreach ($parts as $part) {
+            $parsed = self::parseAtom($part);
+
+            if ($parsed !== null) {
+                $atoms[] = $parsed;
+            }
+        }
+
+        return $atoms;
+    }
+
+    /**
+     * Parse a single Cosmic Truth atom label such as H14, C10, or H14a.
+     *
+     * @return array{element: string, serial: int, suffix: ?string, raw: string}|null
+     */
+    public static function parseAtom(?string $label): ?array
+    {
+        if ($label === null) {
+            return null;
+        }
+
+        $raw = trim($label);
+
+        if ($raw === '') {
+            return null;
+        }
+
+        if (! preg_match('/^([A-Za-z]{1,2})(\d+)([A-Za-z]?)$/', $raw, $matches)) {
+            return null;
+        }
+
+        return [
+            'element' => strtoupper($matches[1]),
+            'serial' => (int) $matches[2],
+            'suffix' => $matches[3] !== '' ? strtolower($matches[3]) : null,
+            'raw' => $raw,
+        ];
+    }
+
+    /**
+     * Pair from/to Cosmic Truth groups for coupling arrows.
+     * Unequal lengths zip only min(count) pairs (no clamping onto the last atom).
+     *
+     * @return list<array{from: array{element: string, serial: int, suffix: ?string, raw: string}, to: array{element: string, serial: int, suffix: ?string, raw: string}}>
+     */
+    public static function pairCoupling(?string $from, ?string $to): array
+    {
+        $fromAtoms = self::parseGroup($from);
+        $toAtoms = self::parseGroup($to);
+
+        if ($fromAtoms === [] || $toAtoms === []) {
+            return [];
+        }
+
+        // Geminal / same-group couplings like H28,H29 → H28,H29 should connect
+        // the two partners, not zip identical endpoints onto themselves.
+        $identicalGroups =
+            count($fromAtoms) === count($toAtoms)
+            && count($fromAtoms) >= 2;
+
+        if ($identicalGroups) {
+            foreach ($fromAtoms as $index => $atom) {
+                if (
+                    ($atom['raw'] ?? null) !== ($toAtoms[$index]['raw'] ?? null)
+                    || ($atom['serial'] ?? null) !== ($toAtoms[$index]['serial'] ?? null)
+                    || ($atom['element'] ?? null) !== ($toAtoms[$index]['element'] ?? null)
+                ) {
+                    $identicalGroups = false;
+                    break;
+                }
+            }
+        }
+
+        if ($identicalGroups) {
+            $pairs = [];
+
+            for ($i = 0; $i < count($fromAtoms) - 1; $i++) {
+                $pairs[] = [
+                    'from' => $fromAtoms[$i],
+                    'to' => $fromAtoms[$i + 1],
+                ];
+            }
+
+            return $pairs;
+        }
+
+        $count = min(count($fromAtoms), count($toAtoms));
+        $pairs = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $pairs[] = [
+                'from' => $fromAtoms[$i],
+                'to' => $toAtoms[$i],
+            ];
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * Pick a study molecule only when InChIKey matches the spin system.
+     * Never fall back to "first SDF" (wrong enantiomer / compound risk).
+     *
+     * @param  iterable<int, object|array<string, mixed>>  $molecules
+     * @param  array<string, mixed>|null  $spinSystem
+     * @return array<string, mixed>|object|null
+     */
+    public static function resolveMolecule(iterable $molecules, ?array $spinSystem = null): mixed
+    {
+        $list = [];
+
+        foreach ($molecules as $molecule) {
+            $list[] = $molecule;
+        }
+
+        if ($list === []) {
+            return null;
+        }
+
+        $inchiKey = is_array($spinSystem)
+            ? ($spinSystem['inchi_key'] ?? null)
+            : null;
+
+        if (! is_string($inchiKey) || $inchiKey === '') {
+            return null;
+        }
+
+        foreach ($list as $molecule) {
+            $candidate = self::moleculeValue($molecule, 'inchi_key')
+                ?? self::moleculeValue($molecule, 'standard_inchi_key');
+
+            if (is_string($candidate) && strcasecmp($candidate, $inchiKey) === 0) {
+                $sdf = self::moleculeValue($molecule, 'sdf');
+
+                if (is_string($sdf) && trim($sdf) !== '') {
+                    return $molecule;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  object|array<string, mixed>  $molecule
+     */
+    private static function moleculeValue(object|array $molecule, string $key): mixed
+    {
+        if (is_array($molecule)) {
+            return $molecule[$key] ?? null;
+        }
+
+        return $molecule->{$key} ?? null;
+    }
+}

--- a/app/Support/Hifsa/HifsaNmriumFileFilter.php
+++ b/app/Support/Hifsa/HifsaNmriumFileFilter.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Support\Hifsa;
+
+/**
+ * NMRium wrapper fileFilter for samples that include HiFSA / Cosmic Truth data.
+ *
+ * Cosmic Truth exports nest EXTRA/ (and often a hifsa/ analysis folder) inside
+ * the study archive. NMRium recursively unpacks those paths and can treat them
+ * as spectra/molecules. The wrapper load event accepts a fileFilter that is
+ * applied for type "url" / "file" loads — see
+ * https://github.com/NFDI4Chem/nmrium-react-wrapper/wiki/3.-Wrapper-Events
+ *
+ * Important: do not set include to []. In file-collection, an empty include
+ * array is truthy and matches nothing, so every file is dropped.
+ */
+class HifsaNmriumFileFilter
+{
+    /**
+     * Path substrings excluded from NMRium parsing when HiFSA data is present.
+     * file-collection matches with path.includes(pattern) (case-sensitive).
+     *
+     * @var list<string>
+     */
+    public const EXCLUDE = [
+        'EXTRA/',
+        'hifsa/',
+        'HiFSA/',
+        'HIFSA/',
+    ];
+
+    /**
+     * True when the study (or study-like array/object) has HiFSA payload or PDF.
+     */
+    public static function studyHasHifsa(mixed $study): bool
+    {
+        if ($study === null) {
+            return false;
+        }
+
+        $hifsaData = self::value($study, 'hifsa_data');
+        $hifsaPdfUrl = self::value($study, 'hifsa_pdf_url');
+
+        if (is_array($hifsaData) && $hifsaData !== []) {
+            return true;
+        }
+
+        return is_string($hifsaPdfUrl) && trim($hifsaPdfUrl) !== '';
+    }
+
+    /**
+     * Wrapper fileFilter for HiFSA samples, or null when filtering is not needed.
+     *
+     * Only `exclude` is set — never pass an empty `include` array.
+     *
+     * @return array{exclude: list<string>}|null
+     */
+    public static function forStudy(mixed $study): ?array
+    {
+        if (! self::studyHasHifsa($study)) {
+            return null;
+        }
+
+        return [
+            'exclude' => self::EXCLUDE,
+        ];
+    }
+
+    private static function value(mixed $study, string $key): mixed
+    {
+        if (is_array($study)) {
+            return $study[$key] ?? null;
+        }
+
+        if (is_object($study)) {
+            return $study->{$key} ?? null;
+        }
+
+        return null;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@vue-hero-icons/outline": "^1.7.2",
                 "@vuepic/vue-datepicker": "^3.3.1",
                 "@vueuse/core": "^8.9.4",
+                "3dmol": "^2.5.5",
                 "axios-retry": "^3.2.5",
                 "crypto-js": "^4.2.0",
                 "dompurify": "^3.0.5",
@@ -2312,6 +2313,22 @@
             "license": "Apache-2.0",
             "peer": true
         },
+        "node_modules/3dmol": {
+            "version": "2.5.5",
+            "resolved": "https://registry.npmjs.org/3dmol/-/3dmol-2.5.5.tgz",
+            "integrity": "sha512-kqNHouGqq3YfW58174tdERvm0XYTmP0tavQKOqIw1ouc2OJ7epkXEFrtEkVXV0clBZT2Ze2xHRC/qxX0u0qCdw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "iobuffer": "^5.0.0",
+                "netcdfjs": "^3.0.0",
+                "pako": "^2.1.0",
+                "upng-js": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=16.16.0",
+                "npm": ">=8.11"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4309,6 +4326,12 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/iobuffer": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+            "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+            "license": "MIT"
+        },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5122,6 +5145,15 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/netcdfjs": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/netcdfjs/-/netcdfjs-3.0.0.tgz",
+            "integrity": "sha512-LOvT8KkC308qtpUkcBPiCMBtii7ZQCN6LxcVheWgyUeZ6DQWcpSRFV9dcVXLj/2eHZ/bre9tV5HTH4Sf93vrFw==",
+            "license": "MIT",
+            "dependencies": {
+                "iobuffer": "^5.3.2"
+            }
+        },
         "node_modules/node-releases": {
             "version": "2.0.54",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
@@ -5283,6 +5315,22 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/pako": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+            "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "(MIT AND Zlib)"
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -6781,6 +6829,21 @@
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
             }
+        },
+        "node_modules/upng-js": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/upng-js/-/upng-js-2.1.0.tgz",
+            "integrity": "sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==",
+            "license": "MIT",
+            "dependencies": {
+                "pako": "^1.0.5"
+            }
+        },
+        "node_modules/upng-js/node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "license": "(MIT AND Zlib)"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "@vue-hero-icons/outline": "^1.7.2",
         "@vuepic/vue-datepicker": "^3.3.1",
         "@vueuse/core": "^8.9.4",
+        "3dmol": "^2.5.5",
         "axios-retry": "^3.2.5",
         "crypto-js": "^4.2.0",
         "dompurify": "^3.0.5",

--- a/resources/js/Pages/Public/Project/Study.vue
+++ b/resources/js/Pages/Public/Project/Study.vue
@@ -158,6 +158,12 @@
                             :study="study.data"
                         />
 
+                        <HifsaPanel
+                            :hifsa-data="study.data.hifsa_data"
+                            :molecules="compositionMolecules"
+                            id-prefix="public-study-hifsa"
+                        />
+
                         <section class="overflow-visible">
                             <div
                                 class="mb-5 flex flex-wrap items-center justify-between gap-3"
@@ -423,6 +429,7 @@ import ProjectLayout from "@/Pages/Public/Project/Layout.vue";
 import { ShareIcon, ClipboardDocumentIcon } from "@heroicons/vue/24/solid";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 import SpectraViewer from "@/Shared/SpectraViewer.vue";
+import HifsaPanel from "@/Shared/HifsaPanel.vue";
 import MolecularInfoPanel from "@/Shared/MolecularInfoPanel.vue";
 import Tag from "@/Shared/Tag.vue";
 import { Head, router } from "@inertiajs/vue3";
@@ -441,6 +448,7 @@ export default {
         MenuItem,
         MenuItems,
         SpectraViewer,
+        HifsaPanel,
         MolecularInfoPanel,
         Tag,
         Head,

--- a/resources/js/Pages/Public/Sample/Show.vue
+++ b/resources/js/Pages/Public/Sample/Show.vue
@@ -307,6 +307,12 @@
                             ></SpectraViewer>
                         </div>
 
+                        <HifsaPanel
+                            :hifsa-data="study.data.hifsa_data"
+                            :molecules="compositionMolecules"
+                            id-prefix="public-sample-hifsa"
+                        />
+
                         <div class="overflow-visible">
                             <div
                                 class="mb-5 flex flex-wrap items-center justify-between gap-3"
@@ -615,6 +621,7 @@ import SampleLayout from "@/Pages/Public/Sample/Layout.vue";
 import { ShareIcon, ClipboardDocumentIcon } from "@heroicons/vue/24/solid";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 import SpectraViewer from "@/Shared/SpectraViewer.vue";
+import HifsaPanel from "@/Shared/HifsaPanel.vue";
 import DOIBadge from "@/Shared/DOIBadge.vue";
 import MolecularInfoPanel from "@/Shared/MolecularInfoPanel.vue";
 import MixtureCompositionDisplay from "@/Shared/MixtureCompositionDisplay.vue";
@@ -633,6 +640,7 @@ export default {
         MenuItem,
         MenuItems,
         SpectraViewer,
+        HifsaPanel,
         DOIBadge,
         MolecularInfoPanel,
         MixtureCompositionDisplay,

--- a/resources/js/Pages/Study/Datasets.vue
+++ b/resources/js/Pages/Study/Datasets.vue
@@ -195,6 +195,16 @@
                                 :project="project"
                                 :study="study"
                             ></SpectraViewer>
+                            <HifsaPanel
+                                class="mt-7"
+                                :hifsa-data="study.hifsa_data"
+                                :molecules="
+                                    study.sample?.molecules ||
+                                    study.molecules ||
+                                    []
+                                "
+                                id-prefix="study-datasets-hifsa"
+                            />
                         </div>
                         <div class="my-2">
                             <div>
@@ -311,6 +321,7 @@ import { ShareIcon, ClipboardDocumentIcon } from "@heroicons/vue/24/solid";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 import SpectraViewer from "@/Shared/SpectraViewer.vue";
 import SpectraEditor from "@/Shared/SpectraEditor.vue";
+import HifsaPanel from "@/Shared/HifsaPanel.vue";
 
 export default {
     components: {
@@ -324,6 +335,7 @@ export default {
         MenuItems,
         SpectraEditor,
         SpectraViewer,
+        HifsaPanel,
     },
     props: [
         "study",

--- a/resources/js/Pages/Upload.vue
+++ b/resources/js/Pages/Upload.vue
@@ -1753,84 +1753,31 @@
                                                                         <div
                                                                             class="mx-auto flex max-w-7xl flex-col gap-3"
                                                                         >
-                                                                            <section
+                                                                            <HifsaPanel
                                                                                 v-if="
-                                                                                    selectedStudy &&
-                                                                                    hasHifsaPanel(
-                                                                                        selectedStudy
-                                                                                    )
+                                                                                    selectedStudy
                                                                                 "
-                                                                                class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm ring-1 ring-gray-900/5 dark:border-gray-700 dark:bg-slate-800/90 dark:ring-white/5"
-                                                                            >
-                                                                                <button
-                                                                                    type="button"
-                                                                                    class="flex w-full items-center justify-between gap-3 border-b border-gray-100 px-3 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-teal-500 dark:border-gray-700 dark:hover:bg-slate-800/80 sm:px-4"
-                                                                                    :aria-expanded="
-                                                                                        hifsaExpanded
-                                                                                    "
-                                                                                    aria-controls="upload-hifsa-panel"
-                                                                                    @click="
-                                                                                        hifsaExpanded =
-                                                                                            !hifsaExpanded
-                                                                                    "
-                                                                                >
-                                                                                    <div
-                                                                                        class="min-w-0 flex-1"
-                                                                                    >
-                                                                                        <h3
-                                                                                            id="upload-hifsa-heading"
-                                                                                            class="text-lg font-semibold tracking-tight text-gray-900 dark:text-slate-100"
-                                                                                        >
-                                                                                            HiFSA
-                                                                                        </h3>
-                                                                                    </div>
-                                                                                    <ChevronRightIcon
-                                                                                        class="h-5 w-5 shrink-0 text-gray-400 transition-transform duration-200 dark:text-slate-500"
-                                                                                        :class="{
-                                                                                            'rotate-90':
-                                                                                                hifsaExpanded,
-                                                                                        }"
-                                                                                        aria-hidden="true"
-                                                                                    />
-                                                                                </button>
-                                                                                <div
-                                                                                    v-show="
-                                                                                        hifsaExpanded
-                                                                                    "
-                                                                                    id="upload-hifsa-panel"
-                                                                                    class="p-3 sm:p-4"
-                                                                                    role="region"
-                                                                                    aria-labelledby="upload-hifsa-heading"
-                                                                                >
-                                                                                    <HifsaScoresPanel
-                                                                                        v-if="
-                                                                                            hasHifsaScores(
-                                                                                                selectedStudy
-                                                                                            )
-                                                                                        "
-                                                                                        :hifsa-data="
-                                                                                            selectedStudy.hifsa_data
-                                                                                        "
-                                                                                    />
-                                                                                    <iframe
-                                                                                        v-else-if="
-                                                                                            selectedStudy.hifsa_pdf_url
-                                                                                        "
-                                                                                        title="HiFSA report"
-                                                                                        frameborder="0"
-                                                                                        class="block w-full rounded-md border"
-                                                                                        style="
-                                                                                            height: min(
-                                                                                                75vh,
-                                                                                                600px
-                                                                                            );
-                                                                                        "
-                                                                                        :src="
-                                                                                            selectedStudy.hifsa_pdf_url
-                                                                                        "
-                                                                                    ></iframe>
-                                                                                </div>
-                                                                            </section>
+                                                                                :hifsa-data="
+                                                                                    selectedStudy.hifsa_data
+                                                                                "
+                                                                                :hifsa-pdf-url="
+                                                                                    selectedStudy.hifsa_pdf_url
+                                                                                "
+                                                                                :molecules="
+                                                                                    selectedStudy
+                                                                                        .sample
+                                                                                        ?.molecules ||
+                                                                                    []
+                                                                                "
+                                                                                :expanded="
+                                                                                    hifsaExpanded
+                                                                                "
+                                                                                id-prefix="upload-hifsa"
+                                                                                @update:expanded="
+                                                                                    hifsaExpanded =
+                                                                                        $event
+                                                                                "
+                                                                            />
 
                                                                             <ChemicalCompositionEditor
                                                                                 v-if="
@@ -2985,7 +2932,7 @@ import {
 } from "@heroicons/vue/24/outline";
 import SpectraEditor from "@/Shared/SpectraEditor.vue";
 import ChemicalCompositionEditor from "@/Shared/ChemicalCompositionEditor.vue";
-import HifsaScoresPanel from "@/Shared/HifsaScoresPanel.vue";
+import HifsaPanel from "@/Shared/HifsaPanel.vue";
 import Depictor from "@/Shared/Depictor.vue";
 import Depictor2D from "@/Shared/Depictor2D.vue";
 import slider from "vue3-slider";
@@ -3007,6 +2954,7 @@ import {
     basisUnitLabel,
     formatMixtureValue,
 } from "@/Utils/mixtureComposition";
+import { studyHasHifsa } from "@/Utils/hifsaNmriumFileFilter.js";
 
 export default {
     components: {
@@ -3028,7 +2976,7 @@ export default {
         Validation,
         SpectraEditor,
         ChemicalCompositionEditor,
-        HifsaScoresPanel,
+        HifsaPanel,
         Depictor,
         Depictor2D,
         slider,
@@ -3718,12 +3666,6 @@ export default {
         this.clearProcessingStuckTimer();
     },
     methods: {
-        hasHifsaScores(study) {
-            return Boolean(study?.hifsa_data?.scores);
-        },
-        hasHifsaPanel(study) {
-            return this.hasHifsaScores(study) || Boolean(study?.hifsa_pdf_url);
-        },
         startProcessingStuckTimer() {
             this.clearProcessingStuckTimer();
             this.isProcessingStuck = false;
@@ -4636,16 +4578,25 @@ export default {
             );
         },
         fetchValidations() {
+            if (!this.project?.id) {
+                return Promise.resolve();
+            }
+
             return axios
                 .get("/projects/" + this.project.id + "/validation")
                 .then((response) => {
                     this.validation = response.data.report;
+                    const studies = this.validation?.project?.studies;
                     this.validationStatus = true;
-                    this.validation.project.studies.forEach((study) => {
-                        if (study.status == false) {
-                            this.validationStatus = false;
-                        }
-                    });
+                    if (!Array.isArray(studies) || studies.length === 0) {
+                        this.validationStatus = false;
+                    } else {
+                        studies.forEach((study) => {
+                            if (study.status == false) {
+                                this.validationStatus = false;
+                            }
+                        });
+                    }
                 });
         },
         /**
@@ -4879,7 +4830,9 @@ export default {
         updateAutoImportList() {
             this.studiesToImport = [];
             this.studies.forEach((study) => {
-                if (!study.has_nmrium) {
+                // HiFSA samples must load via NMRium URL+fileFilter; NMRKit has
+                // no fileFilter and would persist Cosmic Truth EXTRA/ artifacts.
+                if (!study.has_nmrium && !studyHasHifsa(study)) {
                     this.studiesToImport.push({
                         projectSlug: this.project.slug,
                         study: study,

--- a/resources/js/Shared/Hifsa/HifsaMoleculeViewer.vue
+++ b/resources/js/Shared/Hifsa/HifsaMoleculeViewer.vue
@@ -1,0 +1,845 @@
+<template>
+    <div class="flex h-full w-full flex-col">
+        <div
+            v-if="!molfile"
+            class="flex h-full min-h-[16rem] flex-1 items-center justify-center rounded-md border border-dashed border-gray-200 bg-gray-50 px-3 py-8 text-center text-sm text-gray-500 dark:border-slate-600 dark:bg-slate-900/40 dark:text-slate-400"
+        >
+            No linked structure is available to display HiFSA assignments.
+        </div>
+        <div
+            v-else
+            ref="viewerHost"
+            class="relative h-full min-h-[16rem] w-full overflow-hidden rounded-md bg-white dark:bg-slate-950"
+            role="img"
+            :aria-label="ariaLabel"
+        >
+            <div ref="viewerEl" class="absolute inset-0 h-full w-full"></div>
+            <p
+                v-if="loadError"
+                class="absolute inset-0 flex items-center justify-center bg-white/90 px-3 text-center text-sm text-red-600 dark:bg-slate-950/90 dark:text-red-300"
+            >
+                {{ loadError }}
+            </p>
+            <p
+                v-else-if="showInteractionHint"
+                class="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-white/95 to-transparent px-3 pb-3 pt-8 text-center text-xs text-gray-500 dark:from-slate-950/95 dark:text-slate-400"
+            >
+                {{ interactionHint }}
+            </p>
+        </div>
+    </div>
+</template>
+
+<script>
+import {
+    buildCouplingOverlays,
+    buildShiftOverlays,
+} from "@/Utils/hifsaAtomLabels";
+
+const HIGHLIGHT_COLOR = "#f59e0b";
+const ARROW_HIGHLIGHT = "#f59e0b";
+const LABEL_BG = "0x0f172a";
+const LABEL_BG_LIGHT = "0xf8fafc";
+
+export default {
+    name: "HifsaMoleculeViewer",
+    props: {
+        molfile: {
+            type: String,
+            default: null,
+        },
+        /**
+         * Cosmic Truth label → 1-based SDF atom index (from OUTPUT.json `o`+1).
+         */
+        atomMap: {
+            type: Object,
+            default: null,
+        },
+        mode: {
+            type: String,
+            default: "shifts",
+            validator: (value) => ["shifts", "couplings"].includes(value),
+        },
+        rows: {
+            type: Array,
+            default: () => [],
+        },
+        activeRowIndex: {
+            type: Number,
+            default: null,
+        },
+        selectedRowIndex: {
+            type: Number,
+            default: null,
+        },
+    },
+    data() {
+        return {
+            viewer: null,
+            model: null,
+            atoms: [],
+            loadError: null,
+            resizeObserver: null,
+            darkObserver: null,
+            isDark: false,
+            threeDmol: null,
+        };
+    },
+    computed: {
+        highlightedRowIndex() {
+            if (Number.isFinite(this.activeRowIndex)) {
+                return this.activeRowIndex;
+            }
+
+            if (Number.isFinite(this.selectedRowIndex)) {
+                return this.selectedRowIndex;
+            }
+
+            return null;
+        },
+        overlays() {
+            if (!this.assignmentsEnabled) {
+                return [];
+            }
+
+            if (this.mode === "couplings") {
+                return buildCouplingOverlays(this.rows, this.atomMap);
+            }
+
+            return buildShiftOverlays(this.rows, this.atomMap);
+        },
+        assignmentsEnabled() {
+            return Boolean(
+                this.molfile &&
+                    this.atomMap &&
+                    typeof this.atomMap === "object" &&
+                    Object.keys(this.atomMap).length
+            );
+        },
+        showInteractionHint() {
+            return (
+                this.assignmentsEnabled &&
+                !this.loadError &&
+                this.highlightedRowIndex == null
+            );
+        },
+        interactionHint() {
+            if (this.mode === "couplings") {
+                return "Hover or click a coupling row to show J on the structure.";
+            }
+
+            return "Hover or click a chemical-shift row to show δ on the structure.";
+        },
+        ariaLabel() {
+            if (this.mode === "couplings") {
+                return "3D molecule with HiFSA coupling constant arrows";
+            }
+
+            return "3D molecule with HiFSA chemical shift labels";
+        },
+    },
+    watch: {
+        molfile() {
+            this.rebuildViewer();
+        },
+        atomMap: {
+            deep: true,
+            handler() {
+                this.redrawOverlays();
+            },
+        },
+        mode() {
+            this.redrawOverlays();
+        },
+        rows: {
+            deep: true,
+            handler() {
+                this.redrawOverlays();
+            },
+        },
+        highlightedRowIndex() {
+            this.redrawOverlays();
+        },
+    },
+    mounted() {
+        this.isDark = this.detectDarkMode();
+        this.observeDarkMode();
+        this.rebuildViewer();
+    },
+    beforeUnmount() {
+        this.teardownViewer();
+        this.resizeObserver?.disconnect();
+        this.darkObserver?.disconnect();
+    },
+    methods: {
+        detectDarkMode() {
+            if (typeof document === "undefined") {
+                return false;
+            }
+
+            return (
+                document.documentElement.classList.contains("dark") ||
+                document.body?.classList?.contains("dark")
+            );
+        },
+        observeDarkMode() {
+            if (typeof MutationObserver === "undefined") {
+                return;
+            }
+
+            this.darkObserver = new MutationObserver(() => {
+                const next = this.detectDarkMode();
+
+                if (next !== this.isDark) {
+                    this.isDark = next;
+                    this.applyBackground();
+                    this.redrawOverlays();
+                }
+            });
+
+            this.darkObserver.observe(document.documentElement, {
+                attributes: true,
+                attributeFilter: ["class"],
+            });
+
+            if (document.body) {
+                this.darkObserver.observe(document.body, {
+                    attributes: true,
+                    attributeFilter: ["class"],
+                });
+            }
+        },
+        async load3Dmol() {
+            if (this.threeDmol) {
+                return this.threeDmol;
+            }
+
+            const mod = await import("3dmol/build/3Dmol.es6.js");
+            this.threeDmol = mod.default || mod;
+
+            if (typeof this.threeDmol.createViewer !== "function") {
+                throw new Error("3Dmol.js createViewer is unavailable");
+            }
+
+            return this.threeDmol;
+        },
+        async waitForViewerSize(el, attempts = 20) {
+            for (let i = 0; i < attempts; i++) {
+                const width = el.clientWidth;
+                const height = el.clientHeight;
+
+                if (width > 0 && height > 0) {
+                    return true;
+                }
+
+                await new Promise((resolve) =>
+                    requestAnimationFrame(() => resolve())
+                );
+            }
+
+            return el.clientWidth > 0 && el.clientHeight > 0;
+        },
+        async rebuildViewer() {
+            this.teardownViewer();
+            this.loadError = null;
+
+            if (!this.molfile || !String(this.molfile).trim()) {
+                return;
+            }
+
+            await this.$nextTick();
+
+            const host = this.$refs.viewerHost;
+            const el = this.$refs.viewerEl;
+
+            if (!el || !host) {
+                return;
+            }
+
+            try {
+                const sized = await this.waitForViewerSize(host);
+
+                if (!sized) {
+                    throw new Error("Viewer container has no layout size yet");
+                }
+
+                const threeDmol = await this.load3Dmol();
+
+                this.viewer = threeDmol.createViewer(el, {
+                    backgroundColor: this.isDark ? 0x020617 : 0xffffff,
+                    antialias: true,
+                });
+
+                this.model = this.viewer.addModel(this.molfile, "sdf");
+                this.viewer.setStyle(
+                    {},
+                    {
+                        stick: { radius: 0.15 },
+                        sphere: { scale: 0.25 },
+                    }
+                );
+                this.atoms = this.viewer.selectedAtoms({}) || [];
+                this.redrawOverlays();
+                this.viewer.zoomTo();
+                this.viewer.render();
+                this.setupResizeObserver();
+            } catch (error) {
+                console.error(error);
+                this.loadError =
+                    "Could not render the molecular structure in 3D.";
+                this.teardownViewer();
+            }
+        },
+        setupResizeObserver() {
+            this.resizeObserver?.disconnect();
+
+            if (
+                typeof ResizeObserver === "undefined" ||
+                !this.$refs.viewerHost
+            ) {
+                return;
+            }
+
+            this.resizeObserver = new ResizeObserver(() => {
+                if (!this.viewer) {
+                    return;
+                }
+
+                this.viewer.resize();
+                this.viewer.render();
+            });
+
+            this.resizeObserver.observe(this.$refs.viewerHost);
+        },
+        applyBackground() {
+            if (!this.viewer) {
+                return;
+            }
+
+            this.viewer.setBackgroundColor(this.isDark ? 0x020617 : 0xffffff);
+            this.viewer.render();
+        },
+        teardownViewer() {
+            if (this.viewer) {
+                try {
+                    this.viewer.clear();
+                    this.viewer.removeAllModels?.();
+                } catch {
+                    // Viewer may already be disposed with the DOM node.
+                }
+            }
+
+            this.viewer = null;
+            this.model = null;
+            this.atoms = [];
+
+            const el = this.$refs.viewerEl;
+
+            if (el) {
+                el.innerHTML = "";
+            }
+        },
+        redrawOverlays() {
+            if (!this.viewer || !this.atoms.length) {
+                return;
+            }
+
+            this.viewer.removeAllLabels();
+            this.viewer.removeAllShapes();
+            this.viewer.setStyle(
+                {},
+                {
+                    stick: { radius: 0.15 },
+                    sphere: { scale: 0.25 },
+                }
+            );
+
+            if (this.mode === "couplings") {
+                this.drawCouplings();
+            } else {
+                this.drawShifts();
+            }
+
+            this.viewer.render();
+        },
+        drawShifts() {
+            // δ labels are hover/selection-driven to avoid clutter on large NP systems.
+            if (this.highlightedRowIndex == null) {
+                return;
+            }
+
+            for (const overlay of this.overlays) {
+                if (overlay.rowIndex !== this.highlightedRowIndex) {
+                    continue;
+                }
+
+                const resolved = overlay.atoms.flatMap((atom) =>
+                    this.resolveAtoms(atom, { requireExactElement: true })
+                );
+
+                if (resolved.length !== overlay.atoms.length) {
+                    continue;
+                }
+
+                for (const atom of resolved) {
+                    this.viewer.addLabel(overlay.text, {
+                        position: atom,
+                        backgroundColor: this.isDark
+                            ? LABEL_BG
+                            : LABEL_BG_LIGHT,
+                        backgroundOpacity: 0.95,
+                        fontColor: this.isDark ? "white" : "#0f172a",
+                        fontSize: 13,
+                        borderThickness: 1.5,
+                        borderColor: HIGHLIGHT_COLOR,
+                        inFront: true,
+                        showBackground: true,
+                    });
+
+                    this.viewer.setStyle(
+                        { index: atom.index },
+                        {
+                            stick: {
+                                radius: 0.22,
+                                color: HIGHLIGHT_COLOR,
+                            },
+                            sphere: {
+                                scale: 0.35,
+                                color: HIGHLIGHT_COLOR,
+                            },
+                        }
+                    );
+                }
+            }
+        },
+        drawCouplings() {
+            // Coupling arrows/J labels are hover/selection-driven only.
+            if (this.highlightedRowIndex == null) {
+                return;
+            }
+
+            for (const overlay of this.overlays) {
+                if (overlay.rowIndex !== this.highlightedRowIndex) {
+                    continue;
+                }
+
+                for (const pair of overlay.pairs) {
+                    const fromPoint = this.resolveCouplingPoint(pair.from);
+                    const toPoint = this.resolveCouplingPoint(pair.to);
+
+                    // Only draw between real SDF atoms — never invent coordinates.
+                    if (!fromPoint || !toPoint) {
+                        continue;
+                    }
+
+                    if (this.distance3(fromPoint, toPoint) < 0.05) {
+                        continue;
+                    }
+
+                    const points = this.curvedArrowPoints(
+                        fromPoint,
+                        toPoint,
+                        this.moleculeCentroid()
+                    );
+                    this.drawCurvedArrow(points);
+
+                    this.viewer.addLabel(pair.from.raw, {
+                        position: fromPoint,
+                        backgroundColor: this.isDark
+                            ? LABEL_BG
+                            : LABEL_BG_LIGHT,
+                        backgroundOpacity: 0.9,
+                        fontColor: this.isDark ? "white" : "#0f172a",
+                        fontSize: 11,
+                        borderThickness: 1,
+                        borderColor: ARROW_HIGHLIGHT,
+                        inFront: true,
+                        showBackground: true,
+                    });
+
+                    this.viewer.addLabel(pair.to.raw, {
+                        position: toPoint,
+                        backgroundColor: this.isDark
+                            ? LABEL_BG
+                            : LABEL_BG_LIGHT,
+                        backgroundOpacity: 0.9,
+                        fontColor: this.isDark ? "white" : "#0f172a",
+                        fontSize: 11,
+                        borderThickness: 1,
+                        borderColor: ARROW_HIGHLIGHT,
+                        inFront: true,
+                        showBackground: true,
+                    });
+
+                    const labelAt = points[Math.floor(points.length / 2)];
+
+                    this.viewer.addLabel(overlay.text, {
+                        position: {
+                            x: labelAt.x,
+                            y: labelAt.y,
+                            z: labelAt.z,
+                        },
+                        backgroundColor: this.isDark
+                            ? LABEL_BG
+                            : LABEL_BG_LIGHT,
+                        backgroundOpacity: 0.95,
+                        fontColor: this.isDark ? "white" : "#0f172a",
+                        fontSize: 13,
+                        borderThickness: 1.5,
+                        borderColor: ARROW_HIGHLIGHT,
+                        inFront: true,
+                        showBackground: true,
+                    });
+
+                    for (const atom of [fromPoint.atom, toPoint.atom].filter(
+                        Boolean
+                    )) {
+                        this.viewer.setStyle(
+                            { index: atom.index },
+                            {
+                                stick: {
+                                    radius: 0.22,
+                                    color: HIGHLIGHT_COLOR,
+                                },
+                                sphere: {
+                                    scale: 0.35,
+                                    color: HIGHLIGHT_COLOR,
+                                },
+                            }
+                        );
+                    }
+                }
+            }
+        },
+        /**
+         * Resolve a coupling endpoint to a real SDF atom only.
+         * Cosmic Truth `Hn` means the hydrogen on heavy atom n when present;
+         * if that hydrogen is missing from the structure, return null (skip).
+         *
+         * @param {{ element: string, serial: number, suffix: string|null, raw: string }} descriptor
+         * @returns {{x:number,y:number,z:number,atom:object}|null}
+         */
+        resolveCouplingPoint(descriptor) {
+            const atoms = this.resolveAtoms(descriptor, {
+                requireExactElement: true,
+            });
+            const atom = atoms[0] || null;
+
+            if (!atom) {
+                return null;
+            }
+
+            return {
+                x: atom.x,
+                y: atom.y,
+                z: atom.z,
+                atom,
+            };
+        },
+        /**
+         * Draw a smooth quadratic-bezier arrow. Avoid 3Dmol addCurve+toArrow,
+         * which peels too many spline points and leaves a broken shaft.
+         *
+         * @param {Array<{x:number,y:number,z:number}>} points
+         */
+        drawCurvedArrow(points) {
+            if (!points || points.length < 3) {
+                return;
+            }
+
+            const radius = 0.08;
+            const color = 0xf59e0b;
+            const tipLength = Math.min(
+                0.6,
+                Math.max(
+                    0.4,
+                    this.distance3(points[0], points[points.length - 1]) * 0.22
+                )
+            );
+
+            let tipStart = points.length - 2;
+
+            for (let i = points.length - 2; i >= 1; i--) {
+                if (
+                    this.distance3(points[i], points[points.length - 1]) >=
+                    tipLength
+                ) {
+                    tipStart = i;
+                    break;
+                }
+            }
+
+            for (let i = 0; i < tipStart; i++) {
+                this.viewer.addCylinder({
+                    start: {
+                        x: points[i].x,
+                        y: points[i].y,
+                        z: points[i].z,
+                    },
+                    end: {
+                        x: points[i + 1].x,
+                        y: points[i + 1].y,
+                        z: points[i + 1].z,
+                    },
+                    radius,
+                    color,
+                    fromCap: i === 0,
+                    toCap: false,
+                });
+            }
+
+            this.viewer.addArrow({
+                start: {
+                    x: points[tipStart].x,
+                    y: points[tipStart].y,
+                    z: points[tipStart].z,
+                },
+                end: {
+                    x: points[points.length - 1].x,
+                    y: points[points.length - 1].y,
+                    z: points[points.length - 1].z,
+                },
+                radius,
+                radiusRatio: 2.4,
+                mid: 0.01,
+                color,
+            });
+        },
+        distance3(a, b) {
+            return Math.hypot(b.x - a.x, b.y - a.y, b.z - a.z);
+        },
+        /**
+         * Average atom position — used to bend coupling arrows outward.
+         *
+         * @returns {{x:number,y:number,z:number}}
+         */
+        moleculeCentroid() {
+            if (!this.atoms.length) {
+                return { x: 0, y: 0, z: 0 };
+            }
+
+            let x = 0;
+            let y = 0;
+            let z = 0;
+
+            for (const atom of this.atoms) {
+                x += atom.x;
+                y += atom.y;
+                z += atom.z;
+            }
+
+            const n = this.atoms.length;
+
+            return { x: x / n, y: y / n, z: z / n };
+        },
+        /**
+         * Sample a quadratic Bezier from→to with the bulge forced outward
+         * from the molecule centroid (never through the structure).
+         *
+         * @param {{x:number,y:number,z:number}} from
+         * @param {{x:number,y:number,z:number}} to
+         * @param {{x:number,y:number,z:number}} centroid
+         * @returns {Array<{x:number,y:number,z:number}>}
+         */
+        curvedArrowPoints(from, to, centroid = { x: 0, y: 0, z: 0 }) {
+            const dx = to.x - from.x;
+            const dy = to.y - from.y;
+            const dz = to.z - from.z;
+            const length = Math.hypot(dx, dy, dz) || 1;
+            const mid = {
+                x: (from.x + to.x) / 2,
+                y: (from.y + to.y) / 2,
+                z: (from.z + to.z) / 2,
+            };
+
+            // Radial direction from molecule center toward the chord midpoint.
+            let ox = mid.x - centroid.x;
+            let oy = mid.y - centroid.y;
+            let oz = mid.z - centroid.z;
+
+            // Remove the component parallel to the arrow so the bulge is
+            // perpendicular and still reads as from→to.
+            const along = (ox * dx + oy * dy + oz * dz) / (length * length);
+            ox -= along * dx;
+            oy -= along * dy;
+            oz -= along * dz;
+
+            let outwardLength = Math.hypot(ox, oy, oz);
+
+            if (outwardLength < 1e-6) {
+                // Degenerate (mid near center): fall back to a world-up cross.
+                ox = dy * 1 - dz * 0;
+                oy = dz * 0 - dx * 1;
+                oz = dx * 0 - dy * 0;
+                outwardLength = Math.hypot(ox, oy, oz);
+
+                if (outwardLength < 1e-6) {
+                    ox = 0;
+                    oy = 1;
+                    oz = 0;
+                    outwardLength = 1;
+                }
+            }
+
+            const bulge = Math.min(1.8, Math.max(0.7, length * 0.45));
+            const scale = bulge / outwardLength;
+            const control = {
+                x: mid.x + ox * scale,
+                y: mid.y + oy * scale,
+                z: mid.z + oz * scale,
+            };
+
+            const steps = 24;
+            const points = [];
+
+            for (let i = 0; i <= steps; i++) {
+                const t = i / steps;
+                const oneMinus = 1 - t;
+                points.push({
+                    x:
+                        oneMinus * oneMinus * from.x +
+                        2 * oneMinus * t * control.x +
+                        t * t * to.x,
+                    y:
+                        oneMinus * oneMinus * from.y +
+                        2 * oneMinus * t * control.y +
+                        t * t * to.y,
+                    z:
+                        oneMinus * oneMinus * from.z +
+                        2 * oneMinus * t * control.z +
+                        t * t * to.z,
+                });
+            }
+
+            return points;
+        },
+        /**
+         * Map a Cosmic Truth atom descriptor onto 3Dmol atoms (1-based serial).
+         *
+         * @param {{ element: string, serial: number, suffix: string|null }} descriptor
+         * @returns {object[]}
+         */
+        /**
+         * Cosmic Truth uses 1-based SDF atom numbers. 3Dmol may expose those as
+         * 1-based serials (V2000) or 0-based serials/index (V3000).
+         */
+        atomsForSerial(serial) {
+            if (!Number.isFinite(serial) || serial < 1) {
+                return [];
+            }
+
+            const serials = this.atoms
+                .map((atom) => atom.serial)
+                .filter((value) => typeof value === "number");
+            const minSerial = serials.length > 0 ? Math.min(...serials) : 0;
+            const zeroBased = minSerial === 0;
+            const targetSerial = zeroBased ? serial - 1 : serial;
+
+            let matches = this.atoms.filter(
+                (atom) => atom.serial === targetSerial
+            );
+
+            if (!matches.length) {
+                matches = this.atoms.filter(
+                    (atom) => atom.index === serial - 1
+                );
+            }
+
+            return matches;
+        },
+        resolveAtoms(descriptor, options = {}) {
+            if (!descriptor || !this.atoms.length) {
+                return [];
+            }
+
+            // CT labels are never SDF serials. Without a map entry, skip.
+            const mappedSerial = this.mappedSerialFor(descriptor);
+
+            if (mappedSerial == null) {
+                return [];
+            }
+
+            const mapped = this.atomsForSerial(mappedSerial);
+            const matched = mapped.find(
+                (atom) => atom.elem === descriptor.element
+            );
+
+            if (matched) {
+                return [matched];
+            }
+
+            // Missing exact element (e.g. H mapped onto heavy atom): do not
+            // invent coordinates or fall back to CT serial numbers.
+            if (options.requireExactElement) {
+                return [];
+            }
+
+            return [];
+        },
+        /**
+         * @param {{ raw?: string, element?: string, serial?: number }} descriptor
+         * @returns {number|null}
+         */
+        mappedSerialFor(descriptor) {
+            if (!this.atomMap || typeof this.atomMap !== "object") {
+                return null;
+            }
+
+            const raw =
+                typeof descriptor?.raw === "string"
+                    ? descriptor.raw.trim()
+                    : "";
+
+            if (!raw) {
+                return null;
+            }
+
+            const direct = this.atomMap[raw];
+
+            if (direct != null) {
+                const value = Number(direct);
+
+                return Number.isFinite(value) && value >= 1 ? value : null;
+            }
+
+            // Case-insensitive lookup for map key mismatches.
+            const lower = raw.toLowerCase();
+            const key = Object.keys(this.atomMap).find(
+                (candidate) => candidate.toLowerCase() === lower
+            );
+
+            if (!key) {
+                return null;
+            }
+
+            const value = Number(this.atomMap[key]);
+
+            return Number.isFinite(value) && value >= 1 ? value : null;
+        },
+        /**
+         * Real hydrogens bonded to a heavy atom (bond table, else distance).
+         * Kept for diagnostics; assignment overlays use atomMap only.
+         *
+         * @param {object} heavy
+         * @returns {object[]}
+         */
+        hydrogensOnHeavy(heavy) {
+            const fromBonds = (heavy.bonds || [])
+                .map((bondIndex) => this.atoms[bondIndex])
+                .filter((atom) => atom && atom.elem === "H");
+
+            if (fromBonds.length) {
+                return fromBonds;
+            }
+
+            return this.atoms.filter((atom) => {
+                if (atom.elem !== "H" || atom === heavy) {
+                    return false;
+                }
+
+                return this.distance3(heavy, atom) <= 1.25;
+            });
+        },
+    },
+};
+</script>

--- a/resources/js/Shared/HifsaPanel.vue
+++ b/resources/js/Shared/HifsaPanel.vue
@@ -1,0 +1,115 @@
+<template>
+    <section
+        v-if="hasPanel"
+        class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm ring-1 ring-gray-900/5 dark:border-gray-700 dark:bg-slate-800/90 dark:ring-white/5"
+    >
+        <button
+            type="button"
+            class="flex w-full items-center justify-between gap-3 border-b border-gray-100 px-3 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-teal-500 dark:border-gray-700 dark:hover:bg-slate-800/80 sm:px-4"
+            :aria-expanded="isExpanded"
+            :aria-controls="panelControlId"
+            @click="toggleExpanded"
+        >
+            <div class="min-w-0 flex-1">
+                <h3
+                    :id="headingControlId"
+                    class="text-lg font-semibold tracking-tight text-gray-900 dark:text-slate-100"
+                >
+                    HiFSA
+                </h3>
+            </div>
+            <ChevronRightIcon
+                class="h-5 w-5 shrink-0 text-gray-400 transition-transform duration-200 dark:text-slate-500"
+                :class="{ 'rotate-90': isExpanded }"
+                aria-hidden="true"
+            />
+        </button>
+        <div
+            v-show="isExpanded"
+            :id="panelControlId"
+            class="p-3 sm:p-4"
+            role="region"
+            :aria-labelledby="headingControlId"
+        >
+            <HifsaScoresPanel
+                v-if="hasScores"
+                :hifsa-data="hifsaData"
+                :molecules="molecules"
+            />
+            <iframe
+                v-else-if="hifsaPdfUrl"
+                title="HiFSA report"
+                frameborder="0"
+                class="block w-full rounded-md border"
+                style="height: min(75vh, 600px)"
+                :src="hifsaPdfUrl"
+            ></iframe>
+        </div>
+    </section>
+</template>
+
+<script>
+import { ChevronRightIcon } from "@heroicons/vue/24/outline";
+import HifsaScoresPanel from "@/Shared/HifsaScoresPanel.vue";
+
+export default {
+    name: "HifsaPanel",
+    components: {
+        ChevronRightIcon,
+        HifsaScoresPanel,
+    },
+    props: {
+        hifsaData: {
+            type: Object,
+            default: null,
+        },
+        hifsaPdfUrl: {
+            type: String,
+            default: null,
+        },
+        molecules: {
+            type: Array,
+            default: () => [],
+        },
+        expanded: {
+            type: Boolean,
+            default: true,
+        },
+        idPrefix: {
+            type: String,
+            default: "hifsa",
+        },
+    },
+    emits: ["update:expanded"],
+    data() {
+        return {
+            isExpanded: this.expanded,
+        };
+    },
+    computed: {
+        hasScores() {
+            return Boolean(this.hifsaData?.scores);
+        },
+        hasPanel() {
+            return this.hasScores || Boolean(this.hifsaPdfUrl);
+        },
+        headingControlId() {
+            return `${this.idPrefix}-heading`;
+        },
+        panelControlId() {
+            return `${this.idPrefix}-panel`;
+        },
+    },
+    watch: {
+        expanded(isOpen) {
+            this.isExpanded = isOpen;
+        },
+    },
+    methods: {
+        toggleExpanded() {
+            this.isExpanded = !this.isExpanded;
+            this.$emit("update:expanded", this.isExpanded);
+        },
+    },
+};
+</script>

--- a/resources/js/Shared/HifsaScoresPanel.vue
+++ b/resources/js/Shared/HifsaScoresPanel.vue
@@ -211,7 +211,7 @@
                 </button>
 
                 <div
-                    v-show="expandedSections[section.id]"
+                    v-if="expandedSections[section.id]"
                     class="border-t border-gray-100 dark:border-slate-700"
                 >
                     <div
@@ -299,7 +299,134 @@
                             >
                                 {{ group.name }}
                             </div>
-                            <div class="overflow-x-auto">
+
+                            <div
+                                v-if="section.showViewer && group.showViewer"
+                                class="grid gap-3 border-b border-gray-100 p-3 dark:border-slate-700 lg:grid-cols-2 lg:items-start"
+                            >
+                                <div class="lg:sticky lg:top-3 lg:self-start">
+                                    <HifsaMoleculeViewer
+                                        class="h-[28rem] w-full sm:h-[32rem]"
+                                        :molfile="group.molfile"
+                                        :atom-map="group.atomMap"
+                                        :mode="section.viewerMode"
+                                        :rows="group.rows"
+                                        :active-row-index="
+                                            hoverState[section.id]?.[group.name]
+                                        "
+                                        :selected-row-index="
+                                            selectedState[section.id]?.[
+                                                group.name
+                                            ]
+                                        "
+                                    />
+                                </div>
+                                <div
+                                    class="max-h-[28rem] overflow-auto rounded-md border border-gray-100 dark:border-slate-700 sm:max-h-[32rem]"
+                                >
+                                    <table class="min-w-full text-left text-sm">
+                                        <thead
+                                            class="sticky top-0 z-10 bg-white text-xs uppercase tracking-wide text-gray-500 dark:bg-slate-800 dark:text-slate-400"
+                                        >
+                                            <tr>
+                                                <th
+                                                    v-for="column in section.columns"
+                                                    :key="column.key"
+                                                    class="px-3 py-2 font-medium"
+                                                >
+                                                    {{ column.label }}
+                                                </th>
+                                            </tr>
+                                        </thead>
+                                        <tbody
+                                            class="divide-y divide-gray-100 dark:divide-slate-700"
+                                        >
+                                            <tr
+                                                v-for="(
+                                                    row, rowIndex
+                                                ) in group.rows"
+                                                :key="rowIndex"
+                                                class="cursor-pointer transition-colors"
+                                                :class="[
+                                                    rowHighlightClass(
+                                                        section.id,
+                                                        group.name,
+                                                        rowIndex
+                                                    ),
+                                                    group.assignmentsEnabled &&
+                                                    !rowIsDrawableOnStructure(
+                                                        row,
+                                                        section.viewerMode,
+                                                        group.atomMap
+                                                    )
+                                                        ? 'opacity-50'
+                                                        : '',
+                                                ]"
+                                                :title="
+                                                    rowDrawableTitle(
+                                                        row,
+                                                        section.viewerMode,
+                                                        group
+                                                    )
+                                                "
+                                                @mouseenter="
+                                                    setHover(
+                                                        section.id,
+                                                        group.name,
+                                                        rowIndex
+                                                    )
+                                                "
+                                                @mouseleave="
+                                                    clearHover(
+                                                        section.id,
+                                                        group.name
+                                                    )
+                                                "
+                                                @click="
+                                                    toggleSelected(
+                                                        section.id,
+                                                        group.name,
+                                                        rowIndex
+                                                    )
+                                                "
+                                            >
+                                                <td
+                                                    v-for="column in section.columns"
+                                                    :key="column.key"
+                                                    class="px-3 py-2 text-gray-700 dark:text-slate-300"
+                                                    :class="{
+                                                        'tabular-nums':
+                                                            column.numeric,
+                                                        'font-mono text-xs':
+                                                            column.mono,
+                                                        'max-w-[10rem] truncate':
+                                                            column.truncate,
+                                                    }"
+                                                    :title="
+                                                        column.truncate
+                                                            ? displayCell(
+                                                                  row[
+                                                                      column.key
+                                                                  ],
+                                                                  column
+                                                              )
+                                                            : undefined
+                                                    "
+                                                >
+                                                    {{
+                                                        displayCell(
+                                                            row[column.key],
+                                                            column
+                                                        )
+                                                    }}
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+
+                            <div v-else class="overflow-x-auto">
                                 <table class="min-w-full text-left text-sm">
                                     <thead
                                         class="bg-white text-xs uppercase tracking-wide text-gray-500 dark:bg-slate-800/60 dark:text-slate-400"
@@ -365,6 +492,14 @@
 </template>
 
 <script>
+import HifsaMoleculeViewer from "@/Shared/Hifsa/HifsaMoleculeViewer.vue";
+import {
+    isDisplayableShiftPpm,
+    isSoluteSpinSystem,
+    resolveMolecule,
+    rowIsDrawable,
+} from "@/Utils/hifsaAtomLabels";
+
 const SCORE_AXES = [
     { key: "match", label: "Match" },
     { key: "rms", label: "RMS" },
@@ -395,23 +530,19 @@ const LINESHAPE_COLUMNS = [
     { key: "gaussian", label: "Gaussian", numeric: true, digits: 4 },
 ];
 
-const QMGI_COLUMNS = [
-    { key: "name", label: "Name", truncate: true },
-    { key: "rms", label: "RMS", numeric: true, digits: 3 },
-    { key: "weight", label: "Weight", numeric: true, digits: 3 },
-    { key: "range_min", label: "Range min", numeric: true, digits: 3 },
-    { key: "range_max", label: "Range max", numeric: true, digits: 3 },
-    { key: "over", label: "Over", numeric: true, digits: 2 },
-    { key: "under", label: "Under", numeric: true, digits: 2 },
-    { key: "orphan", label: "Orphan", numeric: true, digits: 2 },
-];
-
 export default {
     name: "HifsaScoresPanel",
+    components: {
+        HifsaMoleculeViewer,
+    },
     props: {
         hifsaData: {
             type: Object,
             required: true,
+        },
+        molecules: {
+            type: Array,
+            default: () => [],
         },
     },
     data() {
@@ -426,8 +557,9 @@ export default {
                 chemical_shifts: false,
                 couplings: false,
                 lineshapes: false,
-                qmgi: false,
             },
+            hoverState: {},
+            selectedState: {},
         };
     },
     computed: {
@@ -485,11 +617,6 @@ export default {
                 ? this.hifsaData.lineshapes
                 : [];
         },
-        qmgi() {
-            return Array.isArray(this.hifsaData?.qmgi)
-                ? this.hifsaData.qmgi
-                : [];
-        },
         detailSections() {
             const sections = [];
 
@@ -509,7 +636,9 @@ export default {
                     title: "Chemical shifts",
                     count: this.chemicalShifts.length,
                     columns: SHIFT_COLUMNS,
-                    groups: this.groupBySpinSystem(this.chemicalShifts),
+                    showViewer: true,
+                    viewerMode: "shifts",
+                    groups: this.groupBySpinSystem(this.chemicalShifts, true),
                 });
             }
 
@@ -520,7 +649,9 @@ export default {
                     title: "Coupling constants",
                     count: this.couplings.length,
                     columns: COUPLING_COLUMNS,
-                    groups: this.groupBySpinSystem(this.couplings),
+                    showViewer: true,
+                    viewerMode: "couplings",
+                    groups: this.groupBySpinSystem(this.couplings, true),
                 });
             }
 
@@ -531,18 +662,7 @@ export default {
                     title: "Lineshapes",
                     count: this.lineshapes.length,
                     columns: LINESHAPE_COLUMNS,
-                    groups: this.groupBySpinSystem(this.lineshapes),
-                });
-            }
-
-            if (this.qmgi.length) {
-                sections.push({
-                    id: "qmgi",
-                    kind: "grouped",
-                    title: "QMGI fit quality",
-                    count: this.qmgi.length,
-                    columns: QMGI_COLUMNS,
-                    groups: this.groupBySpinSystem(this.qmgi),
+                    groups: this.groupBySpinSystem(this.lineshapes, false),
                 });
             }
 
@@ -609,7 +729,7 @@ export default {
         toggleSection(id) {
             this.expandedSections[id] = !this.expandedSections[id];
         },
-        groupBySpinSystem(rows) {
+        groupBySpinSystem(rows, withViewer = false) {
             const groups = new Map();
 
             for (const row of rows) {
@@ -622,10 +742,109 @@ export default {
                 groups.get(name).push(row);
             }
 
-            return Array.from(groups.entries()).map(([name, groupRows]) => ({
-                name,
-                rows: groupRows,
-            }));
+            return Array.from(groups.entries()).map(([name, groupRows]) => {
+                const spinSystem =
+                    this.spinsystems.find((row) => row.name === name) || null;
+                const showViewer =
+                    withViewer && isSoluteSpinSystem(name, this.spinsystems);
+                const hifsaStructures = this.hifsaData?.structures || {};
+                const hifsaMolfile =
+                    typeof hifsaStructures[name] === "string" &&
+                    hifsaStructures[name].trim()
+                        ? hifsaStructures[name]
+                        : null;
+                const atomMaps = this.hifsaData?.atom_maps || {};
+                const rawAtomMap =
+                    atomMaps[name] && typeof atomMaps[name] === "object"
+                        ? atomMaps[name]
+                        : null;
+                // CT atom maps are only valid on CT structures — never on
+                // sample/nmrxiv SDFs (different atom order / heavy-atom only).
+                const assignmentsEnabled = Boolean(
+                    hifsaMolfile && rawAtomMap && Object.keys(rawAtomMap).length
+                );
+                const molecule =
+                    showViewer && !hifsaMolfile
+                        ? resolveMolecule(this.molecules, spinSystem)
+                        : null;
+                const molfile =
+                    hifsaMolfile ||
+                    (typeof molecule?.sdf === "string" && molecule.sdf.trim()
+                        ? molecule.sdf
+                        : null);
+
+                return {
+                    name,
+                    rows: groupRows,
+                    showViewer,
+                    molfile,
+                    atomMap: assignmentsEnabled ? rawAtomMap : null,
+                    assignmentsEnabled,
+                };
+            });
+        },
+        rowIsDrawableOnStructure(row, viewerMode, atomMap) {
+            return rowIsDrawable(row, viewerMode, atomMap);
+        },
+        rowDrawableTitle(row, viewerMode, group) {
+            if (!group.assignmentsEnabled) {
+                return undefined;
+            }
+
+            if (this.rowIsDrawableOnStructure(row, viewerMode, group.atomMap)) {
+                return undefined;
+            }
+
+            return "Not drawable on this structure (unmapped atoms or missing explicit hydrogens).";
+        },
+        setHover(sectionId, groupName, rowIndex) {
+            this.hoverState = {
+                ...this.hoverState,
+                [sectionId]: {
+                    ...(this.hoverState[sectionId] || {}),
+                    [groupName]: rowIndex,
+                },
+            };
+        },
+        clearHover(sectionId, groupName) {
+            if (!this.hoverState[sectionId]) {
+                return;
+            }
+
+            this.hoverState = {
+                ...this.hoverState,
+                [sectionId]: {
+                    ...this.hoverState[sectionId],
+                    [groupName]: null,
+                },
+            };
+        },
+        toggleSelected(sectionId, groupName, rowIndex) {
+            const current = this.selectedState[sectionId]?.[groupName] ?? null;
+
+            this.selectedState = {
+                ...this.selectedState,
+                [sectionId]: {
+                    ...(this.selectedState[sectionId] || {}),
+                    [groupName]: current === rowIndex ? null : rowIndex,
+                },
+            };
+        },
+        rowHighlightClass(sectionId, groupName, rowIndex) {
+            const hovered = this.hoverState[sectionId]?.[groupName];
+            const selected = this.selectedState[sectionId]?.[groupName];
+            const isSelected = selected === rowIndex;
+            const isHovered = hovered === rowIndex;
+
+            if (isSelected) {
+                return "bg-teal-100 ring-1 ring-inset ring-teal-400 dark:bg-teal-900/50 dark:ring-teal-500";
+            }
+
+            if (isHovered) {
+                return "bg-teal-50 dark:bg-teal-900/30";
+            }
+
+            return "bg-white hover:bg-gray-50 dark:bg-slate-800/40 dark:hover:bg-slate-800";
         },
         pointAt(index, distance) {
             const angle =
@@ -676,6 +895,19 @@ export default {
             return by || at;
         },
         displayCell(value, column) {
+            if (column.key === "shift" && !isDisplayableShiftPpm(value)) {
+                return "—";
+            }
+
+            if (
+                column.key === "coupling" &&
+                (typeof value !== "number" ||
+                    !Number.isFinite(value) ||
+                    Math.abs(value) >= 1e6)
+            ) {
+                return "—";
+            }
+
             if (column.numeric) {
                 return this.formatNumber(value, column.digits ?? 3);
             }

--- a/resources/js/Shared/Public/PublicDatasetBody.vue
+++ b/resources/js/Shared/Public/PublicDatasetBody.vue
@@ -150,6 +150,12 @@
                 :study="study.data"
             />
 
+            <HifsaPanel
+                :hifsa-data="study.data.hifsa_data"
+                :molecules="compositionMolecules"
+                id-prefix="public-dataset-hifsa"
+            />
+
             <section
                 v-if="orderedSpectrumInfoRows.length > 0"
                 aria-labelledby="spectrum-info-heading"
@@ -318,6 +324,7 @@
 import { ShareIcon, ClipboardDocumentIcon } from "@heroicons/vue/24/solid";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 import SpectraViewer from "@/Shared/SpectraViewer.vue";
+import HifsaPanel from "@/Shared/HifsaPanel.vue";
 import Citation from "@/Shared/Citation.vue";
 import MolecularInfoPanel from "@/Shared/MolecularInfoPanel.vue";
 import Tag from "@/Shared/Tag.vue";
@@ -378,6 +385,7 @@ export default {
         MenuItem,
         MenuItems,
         SpectraViewer,
+        HifsaPanel,
         Citation,
         MolecularInfoPanel,
         Tag,

--- a/resources/js/Shared/SpectraEditor.vue
+++ b/resources/js/Shared/SpectraEditor.vue
@@ -126,6 +126,7 @@ import {
     requestSelectTab,
     resolveNmriumTargetOrigin,
 } from "@/Utils/nmriumTabPreference.js";
+import { hifsaNmriumFileFilter } from "@/Utils/hifsaNmriumFileFilter.js";
 import {
     ArrowPathIcon,
     ChevronDownIcon,
@@ -807,7 +808,8 @@ export default {
                 iframe,
                 data,
                 this.nmriumTargetOrigin(),
-                getDefaultSpectrumTab(this.$page)
+                getDefaultSpectrumTab(this.$page),
+                hifsaNmriumFileFilter(this.study)
             );
             this.scheduleNmriumHandoff();
         },

--- a/resources/js/Shared/SpectraViewer.vue
+++ b/resources/js/Shared/SpectraViewer.vue
@@ -303,6 +303,7 @@ import {
     requestSelectTab,
     resolveNmriumTargetOrigin,
 } from "@/Utils/nmriumTabPreference.js";
+import { hifsaNmriumFileFilter } from "@/Utils/hifsaNmriumFileFilter.js";
 
 export default {
     components: {
@@ -534,10 +535,17 @@ export default {
         loadFromURL(urls) {
             this.infoLog("Loading Spectra from URL..");
             const iframe = window.frames.NMRiumIframe;
-            this.postLoadToIframe(iframe, {
-                data: urls,
-                type: "url",
-            });
+            this.defaultTabApplied = false;
+            postNmriumLoad(
+                iframe,
+                {
+                    data: urls,
+                    type: "url",
+                },
+                this.nmriumTargetOrigin(),
+                getDefaultSpectrumTab(this.$page),
+                hifsaNmriumFileFilter(this.study)
+            );
         },
         loadMol(molFile) {
             let svgString = null;

--- a/resources/js/Utils/hifsaAtomLabels.js
+++ b/resources/js/Utils/hifsaAtomLabels.js
@@ -1,0 +1,339 @@
+/**
+ * Cosmic Truth / HiFSA atom label helpers (H14, C10,C11, coupling pairs).
+ */
+
+/**
+ * @typedef {{ element: string, serial: number, suffix: string|null, raw: string }} HifsaAtom
+ */
+
+/**
+ * @param {string|null|undefined} label
+ * @returns {HifsaAtom|null}
+ */
+export function parseAtom(label) {
+    if (label == null) {
+        return null;
+    }
+
+    const raw = String(label).trim();
+
+    if (!raw) {
+        return null;
+    }
+
+    const match = raw.match(/^([A-Za-z]{1,2})(\d+)([A-Za-z]?)$/);
+
+    if (!match) {
+        return null;
+    }
+
+    return {
+        element: match[1].toUpperCase(),
+        serial: Number.parseInt(match[2], 10),
+        suffix: match[3] ? match[3].toLowerCase() : null,
+        raw,
+    };
+}
+
+/**
+ * @param {string|null|undefined} name
+ * @returns {HifsaAtom[]}
+ */
+export function parseGroup(name) {
+    if (name == null || String(name).trim() === "") {
+        return [];
+    }
+
+    return String(name)
+        .split(/\s*,\s*/)
+        .map((part) => parseAtom(part))
+        .filter(Boolean);
+}
+
+/**
+ * Zip from/to Cosmic Truth groups for coupling arrows.
+ * Unequal lengths zip only min(len) pairs (no clamping onto the last atom).
+ *
+ * @param {string|null|undefined} from
+ * @param {string|null|undefined} to
+ * @returns {{ from: HifsaAtom, to: HifsaAtom }[]}
+ */
+export function pairCoupling(from, to) {
+    const fromAtoms = parseGroup(from);
+    const toAtoms = parseGroup(to);
+
+    if (!fromAtoms.length || !toAtoms.length) {
+        return [];
+    }
+
+    // Geminal / same-group couplings like H28,H29 → H28,H29 should connect
+    // the two partners, not zip identical endpoints onto themselves.
+    if (
+        fromAtoms.length === toAtoms.length &&
+        fromAtoms.length >= 2 &&
+        fromAtoms.every(
+            (atom, index) =>
+                atom.raw === toAtoms[index].raw &&
+                atom.serial === toAtoms[index].serial &&
+                atom.element === toAtoms[index].element
+        )
+    ) {
+        const pairs = [];
+
+        for (let i = 0; i < fromAtoms.length - 1; i++) {
+            pairs.push({
+                from: fromAtoms[i],
+                to: fromAtoms[i + 1],
+            });
+        }
+
+        return pairs;
+    }
+
+    const count = Math.min(fromAtoms.length, toAtoms.length);
+    const pairs = [];
+
+    for (let i = 0; i < count; i++) {
+        pairs.push({
+            from: fromAtoms[i],
+            to: toAtoms[i],
+        });
+    }
+
+    return pairs;
+}
+
+/**
+ * Pick a study molecule only when InChIKey matches the spin system.
+ * Never fall back to "first SDF" (wrong enantiomer / compound risk).
+ *
+ * @param {Array<object>|null|undefined} molecules
+ * @param {object|null|undefined} spinSystem
+ * @returns {object|null}
+ */
+export function resolveMolecule(molecules, spinSystem = null) {
+    const list = Array.isArray(molecules) ? molecules.filter(Boolean) : [];
+
+    if (!list.length) {
+        return null;
+    }
+
+    const inchiKey = spinSystem?.inchi_key || null;
+
+    if (typeof inchiKey !== "string" || inchiKey === "") {
+        return null;
+    }
+
+    return (
+        list.find((molecule) => {
+            const candidate =
+                molecule.inchi_key || molecule.standard_inchi_key || "";
+            const sdf = molecule.sdf;
+
+            return (
+                typeof candidate === "string" &&
+                candidate.toLowerCase() === inchiKey.toLowerCase() &&
+                typeof sdf === "string" &&
+                sdf.trim() !== ""
+            );
+        }) || null
+    );
+}
+
+/**
+ * Whether a spin-system group should show a structure viewer (solute with SDF).
+ *
+ * @param {string} groupName
+ * @param {Array<object>} spinsystems
+ * @returns {boolean}
+ */
+export function isSoluteSpinSystem(groupName, spinsystems = []) {
+    const systems = Array.isArray(spinsystems) ? spinsystems : [];
+    const match = systems.find(
+        (row) => (row?.name || "") === groupName && row?.ss_type
+    );
+
+    if (match) {
+        return String(match.ss_type).toLowerCase() === "solute";
+    }
+
+    // Fallback: Cosmic Truth often names the solute after the SDF file.
+    return /\.sdf$/i.test(groupName || "");
+}
+
+/**
+ * Cosmic Truth uses large negative sentinels (e.g. -1e12) for unset shifts,
+ * commonly on oxygens and other nuclei without a fitted δ.
+ *
+ * @param {unknown} value
+ * @returns {value is number}
+ */
+export function isDisplayableShiftPpm(value) {
+    return (
+        typeof value === "number" &&
+        Number.isFinite(value) &&
+        Math.abs(value) < 1000
+    );
+}
+
+/**
+ * True when every atom label is present in the Cosmic Truth atom map.
+ *
+ * @param {HifsaAtom[]} atoms
+ * @param {Record<string, number>|null|undefined} atomMap
+ * @returns {boolean}
+ */
+export function groupIsFullyMapped(atoms, atomMap) {
+    if (!Array.isArray(atoms) || !atoms.length) {
+        return false;
+    }
+
+    if (!atomMap || typeof atomMap !== "object") {
+        return false;
+    }
+
+    return atoms.every((atom) => {
+        const index = Number(atomMap[atom.raw]);
+
+        return Number.isFinite(index) && index >= 1;
+    });
+}
+
+/**
+ * Format δ ppm for labels.
+ *
+ * @param {number|null|undefined} value
+ * @param {number} digits
+ * @returns {string|null}
+ */
+export function formatShiftPpm(value, digits = 4) {
+    if (!isDisplayableShiftPpm(value)) {
+        return null;
+    }
+
+    return value.toFixed(digits);
+}
+
+/**
+ * Format J Hz for labels.
+ *
+ * @param {number|null|undefined} value
+ * @param {number} digits
+ * @returns {string|null}
+ */
+export function formatCouplingHz(value, digits = 3) {
+    if (
+        typeof value !== "number" ||
+        !Number.isFinite(value) ||
+        Math.abs(value) >= 1e6
+    ) {
+        return null;
+    }
+
+    return value.toFixed(digits);
+}
+
+/**
+ * Build shift overlay specs for the 3D viewer.
+ *
+ * @param {Array<object>} rows
+ * @param {Record<string, number>|null|undefined} atomMap
+ * @returns {{ rowIndex: number, atoms: HifsaAtom[], text: string, label: string }[]}
+ */
+export function buildShiftOverlays(rows, atomMap = null) {
+    if (!Array.isArray(rows)) {
+        return [];
+    }
+
+    return rows
+        .map((row, rowIndex) => {
+            const atoms = parseGroup(row?.name);
+            const ppm = formatShiftPpm(row?.shift);
+            const label = row?.name || "";
+
+            if (!atoms.length || !ppm || !groupIsFullyMapped(atoms, atomMap)) {
+                return null;
+            }
+
+            return {
+                rowIndex,
+                atoms,
+                label,
+                text: `${label}  ${ppm} ppm`,
+            };
+        })
+        .filter(Boolean);
+}
+
+/**
+ * Build coupling overlay specs (arrows + midpoint J labels).
+ *
+ * @param {Array<object>} rows
+ * @param {Record<string, number>|null|undefined} atomMap
+ * @returns {{ rowIndex: number, pairs: { from: HifsaAtom, to: HifsaAtom }[], text: string, label: string }[]}
+ */
+export function buildCouplingOverlays(rows, atomMap = null) {
+    if (!Array.isArray(rows)) {
+        return [];
+    }
+
+    return rows
+        .map((row, rowIndex) => {
+            const pairs = pairCoupling(row?.shift_from, row?.shift_to);
+            const hz = formatCouplingHz(row?.coupling, 3);
+            const label = row?.name || "";
+
+            if (!pairs.length || !hz) {
+                return null;
+            }
+
+            const allAtoms = pairs.flatMap((pair) => [pair.from, pair.to]);
+
+            if (!groupIsFullyMapped(allAtoms, atomMap)) {
+                return null;
+            }
+
+            return {
+                rowIndex,
+                pairs,
+                label,
+                text: `${hz} Hz`,
+            };
+        })
+        .filter(Boolean);
+}
+
+/**
+ * Whether a chemical-shift or coupling table row can be drawn on the CT structure.
+ *
+ * @param {object} row
+ * @param {"shifts"|"couplings"} mode
+ * @param {Record<string, number>|null|undefined} atomMap
+ * @returns {boolean}
+ */
+export function rowIsDrawable(row, mode, atomMap) {
+    if (!atomMap || typeof atomMap !== "object") {
+        return false;
+    }
+
+    if (mode === "couplings") {
+        const pairs = pairCoupling(row?.shift_from, row?.shift_to);
+
+        if (!pairs.length || !formatCouplingHz(row?.coupling, 3)) {
+            return false;
+        }
+
+        return groupIsFullyMapped(
+            pairs.flatMap((pair) => [pair.from, pair.to]),
+            atomMap
+        );
+    }
+
+    const atoms = parseGroup(row?.name);
+
+    return (
+        atoms.length > 0 &&
+        Boolean(formatShiftPpm(row?.shift)) &&
+        groupIsFullyMapped(atoms, atomMap)
+    );
+}

--- a/resources/js/Utils/hifsaNmriumFileFilter.js
+++ b/resources/js/Utils/hifsaNmriumFileFilter.js
@@ -1,0 +1,61 @@
+/**
+ * NMRium wrapper fileFilter for samples that include HiFSA / Cosmic Truth data.
+ *
+ * Cosmic Truth exports nest EXTRA/ (and often a hifsa/ analysis folder) inside
+ * the study archive. The wrapper applies fileFilter for type "url" / "file"
+ * loads — see
+ * https://github.com/NFDI4Chem/nmrium-react-wrapper/wiki/3.-Wrapper-Events
+ *
+ * Important: do not set include to []. In file-collection, an empty include
+ * array is truthy and matches nothing (Array.some on []), so every file is
+ * dropped — spectra appear empty after load.
+ */
+
+/** @type {string[]} */
+export const HIFSA_NMRIUM_EXCLUDE = ["EXTRA/", "hifsa/", "HiFSA/", "HIFSA/"];
+
+/**
+ * @param {object|null|undefined} study
+ * @returns {boolean}
+ */
+export function studyHasHifsa(study) {
+    if (!study || typeof study !== "object") {
+        return false;
+    }
+
+    const hifsaData = study.hifsa_data;
+    if (
+        hifsaData &&
+        typeof hifsaData === "object" &&
+        !Array.isArray(hifsaData) &&
+        Object.keys(hifsaData).length > 0
+    ) {
+        return true;
+    }
+
+    if (Array.isArray(hifsaData) && hifsaData.length > 0) {
+        return true;
+    }
+
+    const pdfUrl = study.hifsa_pdf_url;
+
+    return typeof pdfUrl === "string" && pdfUrl.trim() !== "";
+}
+
+/**
+ * Wrapper fileFilter for HiFSA samples, or null when filtering is not needed.
+ *
+ * Only `exclude` is set — never pass an empty `include` array.
+ *
+ * @param {object|null|undefined} study
+ * @returns {{ exclude: string[] }|null}
+ */
+export function hifsaNmriumFileFilter(study) {
+    if (!studyHasHifsa(study)) {
+        return null;
+    }
+
+    return {
+        exclude: [...HIFSA_NMRIUM_EXCLUDE],
+    };
+}

--- a/resources/js/Utils/nmriumTabPreference.js
+++ b/resources/js/Utils/nmriumTabPreference.js
@@ -145,17 +145,34 @@ export function withActiveTab(payload, tab) {
 }
 
 /**
+ * @param {object} payload
+ * @param {{ exclude?: string[], include?: string[] }|null|undefined} fileFilter
+ * @returns {object}
+ */
+export function withFileFilter(payload, fileFilter) {
+    if (!fileFilter || typeof fileFilter !== "object") {
+        return payload;
+    }
+
+    return {
+        ...payload,
+        fileFilter,
+    };
+}
+
+/**
  * @param {Window} iframe
  * @param {object} payload
  * @param {string} targetOrigin
  * @param {string|null} tab
+ * @param {{ exclude?: string[], include?: string[] }|null|undefined} [fileFilter]
  */
-export function postNmriumLoad(iframe, payload, targetOrigin, tab) {
+export function postNmriumLoad(iframe, payload, targetOrigin, tab, fileFilter) {
     if (!iframe?.postMessage) {
         return;
     }
 
-    const data = withActiveTab(payload, tab);
+    const data = withFileFilter(withActiveTab(payload, tab), fileFilter);
 
     iframe.postMessage({ type: "nmr-wrapper:load", data }, targetOrigin);
 }

--- a/tests/Feature/Draft/DraftHifsaPdfTest.php
+++ b/tests/Feature/Draft/DraftHifsaPdfTest.php
@@ -111,6 +111,8 @@ class DraftHifsaPdfTest extends TestCase
             $files = [
                 'analysis.csv' => $this->sampleAnalysisCsv(),
                 'EXTRA/compound_REF.csv' => $this->sampleRefCsv(),
+                'spinsystems.sdf' => $this->sampleSpinSystemsSdf(),
+                'EXTRA/compound.sdf_Ss3_OUTPUT.json' => $this->sampleOutputJson(),
             ];
         }
 
@@ -164,6 +166,7 @@ sep=,
 "Ss1","DMSO-d5","Sg1","DMSO-H",1,512,1,1,2.5,1,"H",0.01,,,,,,,
 "Ss3","compound.sdf","Sg2",""C10,C11"",6,3072,2,2,160.1,1,""C10,C11"",-1,,,,,,,
 "Ss3","compound.sdf","Sg3","H14",1,512,1,1,3.75,1,"H14",0.04,,,,,,,
+"Ss3","compound.sdf","Sg4","O7",8,4096,1,1,-1000000000000,1,"O7",-1,,,,,,,
 ,,,,,,,,
 "COUPLING CONSTANTS (Hz)",,,,,,,,,
 "SS CTKey","Spin system","CG CTKey","Name","Shift","Shift","Coupling",,,,,,,,,,,,
@@ -192,6 +195,52 @@ sep=,
 "SSType:","Solute",,,,,,,,
 "AType:","Reference",,,,,,,,
 CSV;
+    }
+
+    private function sampleSpinSystemsSdf(): string
+    {
+        return <<<'SDF'
+compound.sdf
+  Mrv2311 01202612343D
+
+  2  1  0  0  0  0            999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    1.0890 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+M  END
+$$$$
+DMSO-d5
+  Mrv2311 01202612343D
+
+  1  0  0  0  0  0            999 V2000
+    0.0000    0.0000    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+M  END
+$$$$
+SDF;
+    }
+
+    private function sampleOutputJson(): string
+    {
+        // Cosmic Truth labels are NOT SDF serials: H14 maps via o+1 to SDF atom 2.
+        return json_encode([
+            'n' => 'compound.sdf',
+            'id' => 'Ss3',
+            'type' => 100,
+            'a' => [
+                [
+                    'n' => 'C10',
+                    'o' => 0,
+                ],
+                [
+                    'n' => 'H14',
+                    'o' => 1,
+                ],
+                [
+                    'n' => 'C14',
+                    'o' => 0,
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
     }
 
     private function invokeFinalizeProcessing(): mixed
@@ -320,11 +369,13 @@ CSV;
         $this->assertEqualsWithDelta(486.0, $study->hifsa_data['spinsystems'][2]['mw'], 1e-9);
         $this->assertNull($study->hifsa_data['spinsystems'][0]['lrms_min']);
 
-        $this->assertCount(3, $study->hifsa_data['chemical_shifts']);
+        $this->assertCount(4, $study->hifsa_data['chemical_shifts']);
         $this->assertSame('C10,C11', $study->hifsa_data['chemical_shifts'][1]['name']);
         $this->assertSame('C10,C11', $study->hifsa_data['chemical_shifts'][1]['line_shape']);
         $this->assertEqualsWithDelta(160.1, $study->hifsa_data['chemical_shifts'][1]['shift'], 1e-9);
         $this->assertNull($study->hifsa_data['chemical_shifts'][1]['lrms']);
+        $this->assertSame('O7', $study->hifsa_data['chemical_shifts'][3]['name']);
+        $this->assertNull($study->hifsa_data['chemical_shifts'][3]['shift']);
 
         $this->assertCount(2, $study->hifsa_data['couplings']);
         $this->assertSame('C14-H14', $study->hifsa_data['couplings'][0]['name']);
@@ -344,6 +395,41 @@ CSV;
         $this->assertEqualsWithDelta(0.97, $study->hifsa_data['qmgi'][0]['rms'], 1e-9);
         $this->assertEqualsWithDelta(0.3, $study->hifsa_data['qmgi'][0]['under'], 1e-9);
         $this->assertEqualsWithDelta(0.1, $study->hifsa_data['qmgi'][0]['orphan'], 1e-9);
+
+        $this->assertArrayHasKey('structures', $study->hifsa_data);
+        $this->assertArrayHasKey('compound.sdf', $study->hifsa_data['structures']);
+        $this->assertStringContainsString(
+            '3D',
+            explode("\n", $study->hifsa_data['structures']['compound.sdf'])[1] ?? '',
+        );
+        $this->assertStringContainsString(
+            '0.0000    0.0000    1.0890',
+            $study->hifsa_data['structures']['compound.sdf'],
+        );
+
+        $this->assertArrayHasKey('atom_maps', $study->hifsa_data);
+        $this->assertSame([
+            'C10' => 1,
+            'H14' => 2,
+            'C14' => 1,
+        ], $study->hifsa_data['atom_maps']['compound.sdf']);
+
+        $compoundSdf = $study->hifsa_data['structures']['compound.sdf'];
+        $atomElements = [];
+        foreach (preg_split('/\r\n|\r|\n/', $compoundSdf) ?: [] as $line) {
+            if (preg_match('/^\s*-?\d+\.\d+\s+-?\d+\.\d+\s+-?\d+\.\d+\s+([A-Za-z]+)/', $line, $matches)) {
+                $atomElements[] = $matches[1];
+            }
+        }
+
+        foreach ($study->hifsa_data['atom_maps']['compound.sdf'] as $label => $index) {
+            $expectedElement = preg_replace('/\d+.*/', '', $label);
+            $this->assertSame(
+                $expectedElement,
+                $atomElements[$index - 1] ?? null,
+                "Atom map {$label} → {$index} should match SDF element",
+            );
+        }
     }
 
     public function test_finalize_processing_leaves_hifsa_data_null_without_export_zip(): void
@@ -402,6 +488,14 @@ CSV;
                 'couplings' => [],
                 'lineshapes' => [],
                 'qmgi' => [],
+                'structures' => [
+                    'compound.sdf' => "compound.sdf\n",
+                ],
+                'atom_maps' => [
+                    'compound.sdf' => [
+                        'H14' => 2,
+                    ],
+                ],
             ],
         ]);
 
@@ -420,6 +514,148 @@ CSV;
 
         $this->assertSame('https://example.test/existing', $study->fresh()->hifsa_data['url']);
         $this->assertEquals(1.0, $study->fresh()->hifsa_data['scores']['match']);
+    }
+
+    public function test_finalize_processing_upgrades_empty_structures_and_atom_maps(): void
+    {
+        Storage::fake(config('filesystems.default'));
+
+        [$study, , $hifsaFolder] = $this->makeStudyWithHifsaSibling();
+        $study->update([
+            'hifsa_data' => [
+                'url' => 'https://example.test/empty-maps',
+                'remarks' => 'empty structures and atom_maps',
+                'solvent' => 'CDCl3',
+                'temperature' => '300',
+                'scores' => [
+                    'match' => 1.0,
+                    'rms' => 1.0,
+                    'shift_similarity' => 1.0,
+                    'coupling_similarity' => 1.0,
+                    'intensity' => 1.0,
+                ],
+                'spinsystems' => [],
+                'chemical_shifts' => [],
+                'couplings' => [],
+                'lineshapes' => [],
+                'qmgi' => [],
+                'structures' => [],
+                'atom_maps' => [],
+            ],
+        ]);
+
+        $zipPath = 'drafts/compound/hifsa/analysis_export.zip';
+        Storage::disk(config('filesystems.default'))
+            ->put($zipPath, $this->makeExportZipContents());
+
+        FileSystemObject::factory()->file()->create([
+            'draft_id' => $this->draft->id,
+            'parent_id' => $hifsaFolder->id,
+            'name' => 'analysis_export.zip',
+            'path' => '/'.$zipPath,
+        ]);
+
+        $this->invokeFinalizeProcessing();
+
+        $study->refresh();
+        $this->assertSame('https://ctb.nmrsolutions.fi//analysis-v/AnA_test', $study->hifsa_data['url']);
+        $this->assertNotEmpty($study->hifsa_data['structures']);
+        $this->assertNotEmpty($study->hifsa_data['atom_maps']);
+    }
+
+    public function test_finalize_processing_upgrades_hifsa_data_missing_structures(): void
+    {
+        Storage::fake(config('filesystems.default'));
+
+        [$study, , $hifsaFolder] = $this->makeStudyWithHifsaSibling();
+        $study->update([
+            'hifsa_data' => [
+                'url' => 'https://example.test/no-structures',
+                'remarks' => 'missing structures key',
+                'solvent' => 'CDCl3',
+                'temperature' => '300',
+                'scores' => [
+                    'match' => 1.0,
+                    'rms' => 1.0,
+                    'shift_similarity' => 1.0,
+                    'coupling_similarity' => 1.0,
+                    'intensity' => 1.0,
+                ],
+                'spinsystems' => [],
+                'chemical_shifts' => [],
+                'couplings' => [],
+                'lineshapes' => [],
+                'qmgi' => [],
+            ],
+        ]);
+
+        $zipPath = 'drafts/compound/hifsa/analysis_export.zip';
+        Storage::disk(config('filesystems.default'))
+            ->put($zipPath, $this->makeExportZipContents());
+
+        FileSystemObject::factory()->file()->create([
+            'draft_id' => $this->draft->id,
+            'parent_id' => $hifsaFolder->id,
+            'name' => 'analysis_export.zip',
+            'path' => '/'.$zipPath,
+        ]);
+
+        $this->invokeFinalizeProcessing();
+
+        $study->refresh();
+        $this->assertSame('https://ctb.nmrsolutions.fi//analysis-v/AnA_test', $study->hifsa_data['url']);
+        $this->assertArrayHasKey('structures', $study->hifsa_data);
+        $this->assertArrayHasKey('compound.sdf', $study->hifsa_data['structures']);
+        $this->assertArrayHasKey('atom_maps', $study->hifsa_data);
+        $this->assertSame(2, $study->hifsa_data['atom_maps']['compound.sdf']['H14']);
+    }
+
+    public function test_finalize_processing_upgrades_hifsa_data_missing_atom_maps(): void
+    {
+        Storage::fake(config('filesystems.default'));
+
+        [$study, , $hifsaFolder] = $this->makeStudyWithHifsaSibling();
+        $study->update([
+            'hifsa_data' => [
+                'url' => 'https://example.test/no-atom-maps',
+                'remarks' => 'missing atom_maps key',
+                'solvent' => 'CDCl3',
+                'temperature' => '300',
+                'scores' => [
+                    'match' => 1.0,
+                    'rms' => 1.0,
+                    'shift_similarity' => 1.0,
+                    'coupling_similarity' => 1.0,
+                    'intensity' => 1.0,
+                ],
+                'spinsystems' => [],
+                'chemical_shifts' => [],
+                'couplings' => [],
+                'lineshapes' => [],
+                'qmgi' => [],
+                'structures' => [
+                    'compound.sdf' => 'placeholder',
+                ],
+            ],
+        ]);
+
+        $zipPath = 'drafts/compound/hifsa/analysis_export.zip';
+        Storage::disk(config('filesystems.default'))
+            ->put($zipPath, $this->makeExportZipContents());
+
+        FileSystemObject::factory()->file()->create([
+            'draft_id' => $this->draft->id,
+            'parent_id' => $hifsaFolder->id,
+            'name' => 'analysis_export.zip',
+            'path' => '/'.$zipPath,
+        ]);
+
+        $this->invokeFinalizeProcessing();
+
+        $study->refresh();
+        $this->assertSame('https://ctb.nmrsolutions.fi//analysis-v/AnA_test', $study->hifsa_data['url']);
+        $this->assertArrayHasKey('atom_maps', $study->hifsa_data);
+        $this->assertSame(1, $study->hifsa_data['atom_maps']['compound.sdf']['C10']);
     }
 
     public function test_finalize_processing_upgrades_score_only_hifsa_data(): void
@@ -464,6 +700,10 @@ CSV;
         $this->assertArrayHasKey('couplings', $study->hifsa_data);
         $this->assertArrayHasKey('lineshapes', $study->hifsa_data);
         $this->assertArrayHasKey('qmgi', $study->hifsa_data);
+        $this->assertArrayHasKey('structures', $study->hifsa_data);
+        $this->assertArrayHasKey('compound.sdf', $study->hifsa_data['structures']);
+        $this->assertArrayHasKey('atom_maps', $study->hifsa_data);
+        $this->assertArrayHasKey('compound.sdf', $study->hifsa_data['atom_maps']);
     }
 
     public function test_info_upgrades_score_only_hifsa_data(): void

--- a/tests/Feature/Study/PublicHifsaViewTest.php
+++ b/tests/Feature/Study/PublicHifsaViewTest.php
@@ -1,0 +1,345 @@
+<?php
+
+namespace Tests\Feature\Study;
+
+use App\Http\Resources\StudyResource;
+use App\Models\Dataset;
+use App\Models\Molecule;
+use App\Models\Project;
+use App\Models\Sample;
+use App\Models\Study;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PublicHifsaViewTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function hifsaPayload(): array
+    {
+        return [
+            'url' => 'https://ctb.nmrsolutions.fi/analysis-v/AnA_test',
+            'remarks' => 'Good match',
+            'solvent' => 'DMSO-d6',
+            'temperature' => '298.15',
+            'scores' => [
+                'match' => 0.85,
+                'rms' => 0.88,
+                'shift_similarity' => 0.43,
+                'coupling_similarity' => 0.84,
+                'intensity' => 0.99,
+            ],
+            'spinsystems' => [
+                [
+                    'name' => 'compound.sdf',
+                    'ss_type' => 'Solute',
+                    'inchi_key' => 'LGPKJUJXISCYQZ-HTCHUFIESA-N',
+                ],
+            ],
+            'chemical_shifts' => [
+                [
+                    'spin_system' => 'compound.sdf',
+                    'name' => 'H14',
+                    'shift' => 3.75,
+                ],
+            ],
+            'couplings' => [
+                [
+                    'spin_system' => 'compound.sdf',
+                    'name' => 'C14-H14',
+                    'shift_from' => 'C14',
+                    'shift_to' => 'H14',
+                    'coupling' => 141.2,
+                ],
+            ],
+            'lineshapes' => [],
+            'qmgi' => [],
+            'structures' => [
+                'compound.sdf' => <<<'SDF'
+compound.sdf
+  nmrxiv 01202612343D
+
+  3  2  0  0  0  0            999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.5000    0.0000    0.5000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.0000    1.0000    0.2000 O   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+$$$$
+SDF,
+            ],
+            'atom_maps' => [
+                'compound.sdf' => [
+                    'H14' => 1,
+                    'C14' => 1,
+                ],
+            ],
+        ];
+    }
+
+    private function sampleSdf(): string
+    {
+        return <<<'SDF'
+ethanol
+  nmrxiv
+
+  3  2  0  0  0  0            999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.5000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.0000    1.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+$$$$
+SDF;
+    }
+
+    public function test_study_resource_includes_hifsa_data_on_detail_views(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $study = Study::factory()->create([
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'project_id' => Project::factory()->create([
+                'owner_id' => $user->id,
+                'team_id' => $user->currentTeam->id,
+            ])->id,
+            'hifsa_data' => $this->hifsaPayload(),
+        ]);
+
+        $detail = (new StudyResource($study))->lite(false)->resolve();
+        $this->assertSame($this->hifsaPayload()['scores']['match'], $detail['hifsa_data']['scores']['match']);
+        $this->assertSame('DMSO-d6', $detail['hifsa_data']['solvent']);
+        $this->assertCount(1, $detail['hifsa_data']['spinsystems']);
+
+        $lite = (new StudyResource($study))->lite(true)->resolve();
+        $this->assertArrayNotHasKey('hifsa_data', $lite);
+    }
+
+    public function test_study_resource_includes_null_hifsa_data_when_absent(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $study = Study::factory()->create([
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'project_id' => Project::factory()->create([
+                'owner_id' => $user->id,
+                'team_id' => $user->currentTeam->id,
+            ])->id,
+            'hifsa_data' => null,
+        ]);
+
+        $detail = (new StudyResource($study))->lite(false)->resolve();
+        $this->assertArrayHasKey('hifsa_data', $detail);
+        $this->assertNull($detail['hifsa_data']);
+    }
+
+    public function test_public_sample_page_exposes_hifsa_data(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $study = Study::factory()->create([
+            'project_id' => null,
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'is_public' => true,
+            'identifier' => 42,
+            'hifsa_data' => $this->hifsaPayload(),
+        ]);
+
+        $page = $this->assertInertiaPageComponent(
+            $this->get('/sample/S42'),
+            'Public/Sample/Show'
+        );
+
+        $this->assertSame(
+            $this->hifsaPayload()['scores']['match'],
+            $page['props']['study']['data']['hifsa_data']['scores']['match']
+        );
+        $this->assertSame(
+            'compound.sdf',
+            $page['props']['study']['data']['hifsa_data']['spinsystems'][0]['name']
+        );
+    }
+
+    public function test_public_project_study_page_exposes_hifsa_data(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $project = Project::factory()->create([
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'is_public' => true,
+            'identifier' => 7,
+        ]);
+        Study::factory()->create([
+            'project_id' => $project->id,
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'is_public' => true,
+            'identifier' => 43,
+            'hifsa_data' => $this->hifsaPayload(),
+        ]);
+
+        $page = $this->assertInertiaPageComponent(
+            $this->get('/sample/S43'),
+            'Public/Project/Study'
+        );
+
+        $this->assertSame(
+            $this->hifsaPayload()['scores']['intensity'],
+            $page['props']['study']['data']['hifsa_data']['scores']['intensity']
+        );
+    }
+
+    public function test_public_dataset_page_exposes_study_hifsa_data(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $project = Project::factory()->create([
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'is_public' => true,
+            'identifier' => 8,
+        ]);
+        $study = Study::factory()->create([
+            'project_id' => $project->id,
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'is_public' => true,
+            'identifier' => 44,
+            'hifsa_data' => $this->hifsaPayload(),
+        ]);
+        Dataset::factory()->create([
+            'project_id' => $project->id,
+            'study_id' => $study->id,
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'is_public' => true,
+            'identifier' => 9,
+        ]);
+
+        $page = $this->assertInertiaPageComponent(
+            $this->get('/dataset/D9'),
+            'Public/Project/Dataset'
+        );
+
+        $this->assertSame(
+            'Good match',
+            $page['props']['study']['data']['hifsa_data']['remarks']
+        );
+    }
+
+    public function test_dashboard_study_datasets_page_exposes_hifsa_data(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $project = Project::factory()->create([
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+        ]);
+        $study = Study::factory()->create([
+            'project_id' => $project->id,
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'hifsa_data' => $this->hifsaPayload(),
+        ]);
+        $study->users()->attach($user, ['role' => 'creator']);
+
+        $page = $this->assertInertiaPageComponent(
+            $this->actingAs($user)->get(route('dashboard.study.datasets', $study)),
+            'Study/Datasets'
+        );
+
+        $this->assertSame(
+            $this->hifsaPayload()['scores']['match'],
+            $page['props']['study']['hifsa_data']['scores']['match']
+        );
+    }
+
+    public function test_public_sample_page_exposes_hifsa_assignments_and_molecule_sdf(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $study = Study::factory()->create([
+            'project_id' => null,
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'is_public' => true,
+            'identifier' => 45,
+            'hifsa_data' => $this->hifsaPayload(),
+        ]);
+
+        $sample = Sample::factory()->create([
+            'study_id' => $study->id,
+        ]);
+        $molecule = Molecule::factory()->create([
+            'inchi_key' => 'LGPKJUJXISCYQZ-HTCHUFIESA-N',
+            'sdf' => $this->sampleSdf(),
+        ]);
+        $sample->molecules()->attach($molecule);
+
+        $page = $this->assertInertiaPageComponent(
+            $this->get('/sample/S45'),
+            'Public/Sample/Show'
+        );
+
+        $hifsa = $page['props']['study']['data']['hifsa_data'];
+        $this->assertSame('H14', $hifsa['chemical_shifts'][0]['name']);
+        $this->assertSame(3.75, $hifsa['chemical_shifts'][0]['shift']);
+        $this->assertSame('C14', $hifsa['couplings'][0]['shift_from']);
+        $this->assertSame('H14', $hifsa['couplings'][0]['shift_to']);
+        $this->assertSame(141.2, $hifsa['couplings'][0]['coupling']);
+        $this->assertArrayHasKey('structures', $hifsa);
+        $this->assertStringContainsString('3D', explode("\n", $hifsa['structures']['compound.sdf'])[1] ?? '');
+        $this->assertArrayHasKey('atom_maps', $hifsa);
+        $this->assertSame(1, $hifsa['atom_maps']['compound.sdf']['H14']);
+
+        $molecules = $page['props']['study']['data']['molecules']
+            ?? $page['props']['study']['data']['sample']['molecules']
+            ?? [];
+        $this->assertNotEmpty($molecules);
+        $this->assertStringContainsString('V2000', $molecules[0]['sdf']);
+    }
+
+    public function test_dashboard_study_datasets_page_exposes_sample_molecules_with_sdf(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $project = Project::factory()->create([
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+        ]);
+        $study = Study::factory()->create([
+            'project_id' => $project->id,
+            'owner_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'hifsa_data' => $this->hifsaPayload(),
+        ]);
+        $study->users()->attach($user, ['role' => 'creator']);
+
+        $sample = Sample::factory()->create([
+            'study_id' => $study->id,
+            'project_id' => $project->id,
+        ]);
+        $molecule = Molecule::factory()->create([
+            'inchi_key' => 'LGPKJUJXISCYQZ-HTCHUFIESA-N',
+            'sdf' => $this->sampleSdf(),
+        ]);
+        $sample->molecules()->attach($molecule);
+
+        $page = $this->assertInertiaPageComponent(
+            $this->actingAs($user)->get(route('dashboard.study.datasets', $study)),
+            'Study/Datasets'
+        );
+
+        $this->assertSame(
+            $this->hifsaPayload()['scores']['match'],
+            $page['props']['study']['hifsa_data']['scores']['match']
+        );
+        $this->assertNotEmpty($page['props']['study']['sample']['molecules']);
+        $this->assertStringContainsString(
+            'V2000',
+            $page['props']['study']['sample']['molecules'][0]['sdf']
+        );
+    }
+}

--- a/tests/Unit/Hifsa/HifsaAtomLabelsTest.php
+++ b/tests/Unit/Hifsa/HifsaAtomLabelsTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Unit\Hifsa;
+
+use App\Support\Hifsa\HifsaAtomLabels;
+use PHPUnit\Framework\TestCase;
+
+class HifsaAtomLabelsTest extends TestCase
+{
+    public function test_parse_atom_handles_element_serial_and_suffix(): void
+    {
+        $this->assertSame([
+            'element' => 'H',
+            'serial' => 14,
+            'suffix' => null,
+            'raw' => 'H14',
+        ], HifsaAtomLabels::parseAtom('H14'));
+
+        $this->assertSame([
+            'element' => 'H',
+            'serial' => 14,
+            'suffix' => 'a',
+            'raw' => 'H14a',
+        ], HifsaAtomLabels::parseAtom('H14a'));
+
+        $this->assertNull(HifsaAtomLabels::parseAtom('not-an-atom'));
+        $this->assertNull(HifsaAtomLabels::parseAtom(''));
+    }
+
+    public function test_parse_group_splits_equivalent_atoms(): void
+    {
+        $this->assertSame([
+            [
+                'element' => 'C',
+                'serial' => 10,
+                'suffix' => null,
+                'raw' => 'C10',
+            ],
+            [
+                'element' => 'C',
+                'serial' => 11,
+                'suffix' => null,
+                'raw' => 'C11',
+            ],
+        ], HifsaAtomLabels::parseGroup('C10,C11'));
+
+        $this->assertSame([], HifsaAtomLabels::parseGroup(null));
+    }
+
+    public function test_pair_coupling_zips_equivalent_groups(): void
+    {
+        $pairs = HifsaAtomLabels::pairCoupling('C24,C25', 'H24,H25');
+
+        $this->assertCount(2, $pairs);
+        $this->assertSame(24, $pairs[0]['from']['serial']);
+        $this->assertSame(24, $pairs[0]['to']['serial']);
+        $this->assertSame('H', $pairs[0]['to']['element']);
+        $this->assertSame(25, $pairs[1]['from']['serial']);
+        $this->assertSame(25, $pairs[1]['to']['serial']);
+    }
+
+    public function test_pair_coupling_handles_single_from_to(): void
+    {
+        $pairs = HifsaAtomLabels::pairCoupling('C14', 'H14');
+
+        $this->assertCount(1, $pairs);
+        $this->assertSame('C14', $pairs[0]['from']['raw']);
+        $this->assertSame('H14', $pairs[0]['to']['raw']);
+    }
+
+    public function test_pair_coupling_connects_geminal_same_group(): void
+    {
+        $pairs = HifsaAtomLabels::pairCoupling('H28,H29', 'H28,H29');
+
+        $this->assertCount(1, $pairs);
+        $this->assertSame('H28', $pairs[0]['from']['raw']);
+        $this->assertSame('H29', $pairs[0]['to']['raw']);
+    }
+
+    public function test_pair_coupling_does_not_clamp_unequal_group_lengths(): void
+    {
+        $pairs = HifsaAtomLabels::pairCoupling('C24,C25', 'H24');
+
+        $this->assertCount(1, $pairs);
+        $this->assertSame('C24', $pairs[0]['from']['raw']);
+        $this->assertSame('H24', $pairs[0]['to']['raw']);
+    }
+
+    public function test_resolve_molecule_requires_inchi_key_match(): void
+    {
+        $molecules = [
+            [
+                'id' => 1,
+                'inchi_key' => 'OTHERKEY-UHFFFAOYSA-N',
+                'sdf' => "mol1\n",
+            ],
+            [
+                'id' => 2,
+                'inchi_key' => 'LGPKJUJXISCYQZ-HTCHUFIESA-N',
+                'sdf' => "mol2\n",
+            ],
+            [
+                'id' => 3,
+                'inchi_key' => null,
+                'sdf' => null,
+            ],
+        ];
+
+        $matched = HifsaAtomLabels::resolveMolecule($molecules, [
+            'inchi_key' => 'LGPKJUJXISCYQZ-HTCHUFIESA-N',
+        ]);
+
+        $this->assertSame(2, $matched['id']);
+    }
+
+    public function test_resolve_molecule_refuses_wrong_enantiomer_fallback(): void
+    {
+        $molecules = [
+            [
+                'id' => 7,
+                'inchi_key' => 'LGPKJUJXISCYQZ-HTCHUFIESA-N',
+                'sdf' => "7r\n",
+            ],
+            [
+                'id' => 8,
+                'inchi_key' => 'LGPKJUJXISCYQZ-BOXYVWFNSA-N',
+                'sdf' => "7s\n",
+            ],
+        ];
+
+        $matched = HifsaAtomLabels::resolveMolecule($molecules, [
+            'inchi_key' => 'LGPKJUJXISCYQZ-BOXYVWFNSA-N',
+        ]);
+
+        $this->assertSame(8, $matched['id']);
+
+        $this->assertNull(HifsaAtomLabels::resolveMolecule($molecules, [
+            'inchi_key' => 'MISSING-UHFFFAOYSA-N',
+        ]));
+
+        $this->assertNull(HifsaAtomLabels::resolveMolecule($molecules, [
+            'inchi_key' => null,
+        ]));
+
+        $this->assertNull(HifsaAtomLabels::resolveMolecule([
+            ['id' => 11, 'sdf' => "has-sdf\n"],
+        ], ['inchi_key' => 'MISSING']));
+    }
+}

--- a/tests/Unit/Hifsa/HifsaNmriumFileFilterTest.php
+++ b/tests/Unit/Hifsa/HifsaNmriumFileFilterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Hifsa;
+
+use App\Support\Hifsa\HifsaNmriumFileFilter;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class HifsaNmriumFileFilterTest extends TestCase
+{
+    public function test_for_study_returns_null_without_hifsa(): void
+    {
+        $this->assertNull(HifsaNmriumFileFilter::forStudy(null));
+        $this->assertNull(HifsaNmriumFileFilter::forStudy([]));
+        $this->assertNull(HifsaNmriumFileFilter::forStudy([
+            'hifsa_data' => null,
+            'hifsa_pdf_url' => null,
+        ]));
+        $this->assertNull(HifsaNmriumFileFilter::forStudy([
+            'hifsa_data' => [],
+            'hifsa_pdf_url' => '',
+        ]));
+    }
+
+    public function test_for_study_returns_exclude_only_when_hifsa_data_present(): void
+    {
+        $filter = HifsaNmriumFileFilter::forStudy([
+            'hifsa_data' => [
+                'scores' => ['match' => 0.9],
+            ],
+        ]);
+
+        $this->assertSame([
+            'exclude' => ['EXTRA/', 'hifsa/', 'HiFSA/', 'HIFSA/'],
+        ], $filter);
+        $this->assertArrayNotHasKey('include', $filter);
+    }
+
+    public function test_for_study_returns_filter_when_hifsa_pdf_url_present(): void
+    {
+        $filter = HifsaNmriumFileFilter::forStudy([
+            'hifsa_pdf_url' => '/dashboard/drafts/1/hifsa/2',
+        ]);
+
+        $this->assertSame([
+            'exclude' => ['EXTRA/', 'hifsa/', 'HiFSA/', 'HIFSA/'],
+        ], $filter);
+        $this->assertArrayNotHasKey('include', $filter);
+    }
+
+    public function test_study_has_hifsa_reads_object_properties(): void
+    {
+        $study = new stdClass;
+        $study->hifsa_data = null;
+        $study->hifsa_pdf_url = ' https://example.test/report.pdf ';
+
+        $this->assertTrue(HifsaNmriumFileFilter::studyHasHifsa($study));
+        $this->assertNotNull(HifsaNmriumFileFilter::forStudy($study));
+    }
+}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -26,10 +26,10 @@ export default defineConfig({
             '@': '/resources/js',
             'ziggy-js': path.resolve('vendor/tightenco/ziggy'),
         },
-        dedupe: ['openchemlib'],
+        dedupe: ['openchemlib', '3dmol'],
     },
     optimizeDeps: {
-        include: ['openchemlib'],
+        include: ['openchemlib', '3dmol'],
     },
     server: {
         host: '0.0.0.0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,6 +1156,16 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"3dmol@^2.5.5":
+  version "2.5.5"
+  resolved "https://registry.npmjs.org/3dmol/-/3dmol-2.5.5.tgz"
+  integrity sha512-kqNHouGqq3YfW58174tdERvm0XYTmP0tavQKOqIw1ouc2OJ7epkXEFrtEkVXV0clBZT2Ze2xHRC/qxX0u0qCdw==
+  dependencies:
+    iobuffer "^5.0.0"
+    netcdfjs "^3.0.0"
+    pako "^2.1.0"
+    upng-js "^2.1.0"
+
 acorn-import-phases@^1.0.3:
   version "1.0.4"
   resolved "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz"
@@ -2252,6 +2262,11 @@ inherits@2:
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+iobuffer@^5.0.0, iobuffer@^5.3.2:
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz"
+  integrity sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz"
@@ -2657,6 +2672,13 @@ neo-async@^2.6.2:
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+netcdfjs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/netcdfjs/-/netcdfjs-3.0.0.tgz"
+  integrity sha512-LOvT8KkC308qtpUkcBPiCMBtii7ZQCN6LxcVheWgyUeZ6DQWcpSRFV9dcVXLj/2eHZ/bre9tV5HTH4Sf93vrFw==
+  dependencies:
+    iobuffer "^5.3.2"
+
 node-releases@^2.0.53:
   version "2.0.54"
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz"
@@ -2747,6 +2769,16 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+pako@^1.0.5:
+  version "1.0.11"
+  resolved "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
+pako@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz"
+  integrity sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -3535,6 +3567,13 @@ update-browserslist-db@^1.3.0:
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
+
+upng-js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/upng-js/-/upng-js-2.1.0.tgz"
+  integrity sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==
+  dependencies:
+    pako "^1.0.5"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
## Summary
- Parse Cosmic Truth `spinsystems.sdf` and `OUTPUT.json` atom maps into study `hifsa_data`, and hide sentinel shift/coupling values.
- Add a 3Dmol.js assignment viewer and shared `HifsaPanel` on upload, dashboard datasets, and public study/sample/dataset pages.
- Pass an NMRium `fileFilter` that excludes `EXTRA/` and `hifsa/` paths so Cosmic Truth artifacts are not loaded as spectra.

This app does not use Filament. Backend helpers follow Laravel 13 conventions (typed support classes, API resource `when()`, eager-loaded `sample.molecules` for the datasets view).

## Test plan
- [ ] Open a HiFSA study in upload and confirm the HiFSA panel shows scores plus shift/coupling overlays on the CT structure.
- [ ] Confirm public study, sample, and dataset pages render the same panel when `hifsa_data` is present, and hide it when absent.
- [ ] Load a HiFSA sample in NMRium and confirm EXTRA/hifsa files are not imported as spectra.
- [ ] `php artisan test --filter='HifsaAtomLabelsTest|HifsaNmriumFileFilterTest|DraftHifsaPdfTest|PublicHifsaViewTest'`