### PR TITLE
fix(ui): resolve file-browser license title and ignore invalid selected ids

### DIFF
--- a/resources/js/Shared/Children.vue
+++ b/resources/js/Shared/Children.vue
@@ -1086,6 +1086,10 @@ export default {
          * @param {String|Number} selectedId - ID of the selected file/folder
          */
         updateURLWithSelection(selectedId) {
+            if (selectedId == null || selectedId === "") {
+                return;
+            }
+
             // Parse current URL parameters
             const urlParams = new URLSearchParams(window.location.search);
 

--- a/resources/js/Shared/FileSystemBrowser.vue
+++ b/resources/js/Shared/FileSystemBrowser.vue
@@ -1568,7 +1568,7 @@
         :show="showDownloadTerms"
         :download-url="pendingDownloadUrl"
         :download-identifier="pendingDownloadIdentifier"
-        :license-title="project?.license?.title || study?.license?.title"
+        :license-title="licenseTitle"
         @close="closeDownloadTerms"
     />
 </template>
@@ -1703,6 +1703,7 @@ export default {
      * @prop {Boolean} readonly - Whether the browser is in read-only mode
      * @prop {String} height - Tailwind height classes for the root #fs-dropzone (e.g. h-full min-h-0 when the parent establishes height via flex).
      * @prop {Object} project - Project object for public file access (optional)
+     * @prop {Object} study - Study object for public file access (optional)
      * @prop {Boolean} treeOnly - Show only the folder tree (hide details panel)
      */
     props: [
@@ -1710,6 +1711,7 @@ export default {
         "readonly",
         "height",
         "project",
+        "study",
         "treeOnly",
         "studies",
         "submittedStudyIds",
@@ -1912,15 +1914,32 @@ export default {
             }
         },
 
+        resolvedStudy() {
+            if (this.study) {
+                return this.study;
+            }
+
+            return (
+                this.$page.props.study?.data ?? this.$page.props.study ?? null
+            );
+        },
+
+        licenseTitle() {
+            return (
+                this.project?.license?.title ||
+                this.resolvedStudy?.license?.title ||
+                null
+            );
+        },
+
         downloadTrackingIdentifier() {
             if (this.project) {
                 return this.trackingIdentifier(this.project);
             }
 
-            const study =
-                this.$page.props.study?.data ?? this.$page.props.study;
-
-            return study ? this.trackingIdentifier(study) : null;
+            return this.resolvedStudy
+                ? this.trackingIdentifier(this.resolvedStudy)
+                : null;
         },
 
         /**
@@ -4094,9 +4113,14 @@ export default {
             let targetId = null;
 
             // First try to use the selected parameter from URL
-            if (selectedParam) {
-                targetId = parseInt(selectedParam);
-            } else {
+            if (selectedParam && selectedParam !== "undefined") {
+                const parsed = parseInt(selectedParam, 10);
+                if (!Number.isNaN(parsed)) {
+                    targetId = parsed;
+                }
+            }
+
+            if (targetId == null) {
                 // Fall back to last expanded folder
                 const expandedIds = Array.from(this.expandedFolders);
                 if (expandedIds.length === 0) return;

--- a/tests/Unit/FileSystemBrowserLicenseTitleTest.php
+++ b/tests/Unit/FileSystemBrowserLicenseTitleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class FileSystemBrowserLicenseTitleTest extends TestCase
+{
+    #[Test]
+    public function download_terms_modal_does_not_read_undeclared_study_during_render(): void
+    {
+        $path = resource_path('js/Shared/FileSystemBrowser.vue');
+
+        $this->assertFileExists($path);
+
+        $contents = file_get_contents($path);
+
+        $this->assertNotFalse($contents);
+
+        [$template] = explode('<script>', $contents, 2);
+
+        $this->assertStringContainsString(':license-title="licenseTitle"', $template);
+        $this->assertStringNotContainsString('study?.license', $template);
+        $this->assertStringContainsString('"study"', $contents);
+        $this->assertStringContainsString('licenseTitle()', $contents);
+        $this->assertStringContainsString('resolvedStudy()', $contents);
+    }
+}


### PR DESCRIPTION
## Summary
- Declare the `study` prop and compute download-terms `licenseTitle` from project or study so Vue no longer reads an undeclared `study` in the template.
- Ignore empty or non-numeric `selected` query params so the file browser does not write `selected=undefined` into the URL.

## Test plan
- [ ] Open a public study file browser and confirm the download-terms modal shows the study license title.
- [ ] Select a file, then clear/invalid `?selected=` and confirm the URL is not updated with `undefined`.
- [ ] `php artisan test --filter=FileSystemBrowserLicenseTitleTest`